### PR TITLE
Add firefox/features/shared.ftl

### DIFF
--- a/en-US/firefox/features/shared.ftl
+++ b/en-US/firefox/features/shared.ftl
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+features-shared-a-better-internet-experience = A better internetting experience

--- a/en/firefox/features/shared.ftl
+++ b/en/firefox/features/shared.ftl
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+features-shared-a-better-internet-experience = A better internet experience
+
+features-shared-browse-faster = Browse faster
+features-shared-your-favorite-extensions = Your favorite extensions
+features-shared-balanced-memory = Balanced memory
+features-shared-more-powerful-private-browsing = More powerful Private Browsing
+features-shared-ad-tracker-blocking = Ad tracker blocking
+features-shared-password-manager = Password manager
+features-shared-customize-your-browser = Customize your browser
+features-shared-sync-between-devices = Sync between devices
+features-shared-better-bookmarks = Better bookmarks
+
+brand-name-firefox = { -brand-name-firefox }


### PR DESCRIPTION
Most of these strings were previously just on the features index page but now they reoccur on all the sub-pages as well, so we created this new shared file. So even though they used to exist elsewhere and they've been translated before, this is a brand new file so there's nothing to migrate.