### PR TITLE
Add firefox/features/index.ftl

### DIFF
--- a/ach/firefox/features/index.ftl
+++ b/ach/firefox/features/index.ftl
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Gwok mung mamegi ki yeny oyot ki jami me { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Itye iloc ki jami me { -brand-name-firefox } ma gwoko mung mamegi ki dwiro me yeny.
+# Hero title
+features-index-firefox-features = Jami me firefox
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Med-ikome ki lamed mamegi ma imaro
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Yub layeny mamegi
+# Obsolete string
+features-index-tabs-that-travel = Dirica matino ma woto
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Alamabuk maber
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Yeny oyoto
+# Obsolete string
+features-index-were-always-transparent = Jwijwi wabedo atyer.
+# Obsolete string
+features-index-see-what-makes-us-different = Nen ngo ma weko wabedo pat
+features-index-by-non-profit-mozilla = Gwok yotkom pa internet
+# Obsolete string
+features-index-protecting-the-health-of-the = Gwoko yotkom pa intanet.
+features-index-read-mozillas-mission = Kwan Miti pa { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Gwok tweroni
+features-index-choose-independence = Yer cung pire kene
+features-index-read-our-privacy-policy = Kwan cik me mung mamegwa
+# Obsolete string
+features-index-more-private = Mung maloyo
+features-index-we-dont-sell-access-to-your = Pe wacato nongo data mamegi me wiyamo. Otum.
+features-index-get-firefox-for-privacy = Nong { -brand-name-firefox } pi mung

--- a/af/firefox/features/index.ftl
+++ b/af/firefox/features/index.ftl
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Beskerm u privaatheid en blaai vinniger met { -brand-name-firefox } se funksionaliteit

--- a/an/firefox/features/index.ftl
+++ b/an/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Proteche la tuya privacidat y navega mas rapido con las funcionalidatz de { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Tiens lo control con as funcionalidatz facils d'usar de { -brand-name-firefox } que protechen la tuya privacidat y la velocidat de navegación.
+# Hero title
+features-index-firefox-features = Funcionalidatz de { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Explora las funcionalidatz d'o nuevo navegador { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Los tuyos complementos y extensions favoritos
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personaliza lo tuyo navegador
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincroniza entre dispositivos
+# Obsolete string
+features-index-tabs-that-travel = Pestanyas que viacheyan
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Millors marcapachinas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navegación privada millorada
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Bloqueyo de trazadors d'anuncios
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Chestor de claus
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Uso de memoria equilibrau
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Navega mas rapido
+# Obsolete string
+features-index-firefox-product-benefits = Los avantaches d'o { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Codigo ubierto
+# Obsolete string
+features-index-were-always-transparent = Siempre transparents.
+# Obsolete string
+features-index-see-what-makes-us-different = Mira lo que nos fa diferents
+features-index-by-non-profit-mozilla = Por { -brand-name-mozilla }, sin animo de lucro
+# Obsolete string
+features-index-protecting-the-health-of-the = Protechendo la buena salut d'internet.
+features-index-read-mozillas-mission = Leye la misión de { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Proteche los tuyos dreitos
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Aduyamos a controlar los poders d'as grans interpresas.
+features-index-choose-independence = Triga independencia
+# Obsolete string
+features-index-limited-data-collection = Replega de datos limitada
+features-index-opted-in-to-privacy-so-you = Optamos per la privacidat, pa que puedas navegar librement.
+features-index-read-our-privacy-policy = Leye la nuestra politica de privacidat
+# Obsolete string
+features-index-more-private = Mas privau
+features-index-we-dont-sell-access-to-your = No vendemos l'acceso a los tuyos datos en linia. Y punto pelota.
+features-index-get-firefox-for-privacy = Obtiene { -brand-name-firefox } per la privacidat

--- a/ar/firefox/features/index.ftl
+++ b/ar/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = احمِ بياناتك الخاصّة وتصفّح الإنترنت بشكل أسرع مع مُختلف خصائص فَيَرفُكس
+# HTML page description
+features-index-youre-in-control-with-firefoxs = لديك تحكّم أفضل في خصائص فَيَرفُكس سهلة الاستخدام التي تحمي خصوصيتك وسرعة تصفّحك للإنترنت.
+# Hero title
+features-index-firefox-features = خصائص فَيَرفُكس
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = استكشف المزايا الجديدة لمُتصفح فَيَرفُكس الجديد كلّيًا
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = إضافاتك ومُلحقاتك المُفضّلة
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = خصّص مُتصفّحك
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = زامن ما بين مُختلف أجهزتك
+# Obsolete string
+features-index-tabs-that-travel = انقل معك جميع الألسنة المفتوحة
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = علامات أفضل
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = وضع <i>تصفّح خاص</i> أقوى
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = حجب المتعقّبات الإعلانية
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = مُدير كلمات السّر
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = استهلاك مُتوازن للذّاكرة
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = تصفّح بشكل أسرع
+# Obsolete string
+features-index-firefox-product-benefits = فوائد منتجات فَيَرفُكس
+# Obsolete string
+features-index-open-source = مفتوح المصدر
+# Obsolete string
+features-index-were-always-transparent = نعمل بكل شفافيّة.
+# Obsolete string
+features-index-see-what-makes-us-different = اكتشف ما يجعلنا مُختلفين عن غيرنا
+features-index-by-non-profit-mozilla = برعاية مؤسّسّة موزيلا غير الربحية
+# Obsolete string
+features-index-protecting-the-health-of-the = نحمي صحّة الإنترنت.
+features-index-read-mozillas-mission = اطّلع على مهمّة موزيلا
+# Obsolete string
+features-index-protect-your-rights = نحمي حُقوقك
+# Obsolete string
+features-index-we-help-keep-corporate-powers = نعمل على التّصدّي لأطماع الشّركات الرّبحيّة.
+features-index-choose-independence = اختر الاستقلالية
+# Obsolete string
+features-index-limited-data-collection = تجميع محدود للبيانات
+features-index-opted-in-to-privacy-so-you = نوفّر حماية قوية لخصوصيتك بشكل قياسي لكي تستطيع التّصفّح بكل حرّيّة.
+features-index-read-our-privacy-policy = اطّلع على سياساتنا المُتعلّقة بالخصوصيّة
+# Obsolete string
+features-index-more-private = خصوصية أفضل
+features-index-we-dont-sell-access-to-your = لا نبيع بياناتك الخّاصّة. لا مُساومة مع ذلك.
+features-index-get-firefox-for-privacy = استخدم فَيَرفُكس لتحميَ خصوصيتك على الإنترنت

--- a/ast/firefox/features/index.ftl
+++ b/ast/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protexi la to privacidá y restola más rápido coles carauterístiques de { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Tienes el control coles carauterístiques fáciles d'usar de { -brand-name-firefox } que protexen la to privacidá y aceleren el restolar.
+# Hero title
+features-index-firefox-features = Carauterístiques de { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Esplora les carauterístiques del restolador nuevu { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Les tos estensiones y complementos favoritos
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personaliza'l to restolador
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincronización ente preseos
+# Obsolete string
+features-index-tabs-that-travel = Llingüetes que viaxen
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Marcadores meyores
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Restolar en privao más poderosu
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Bloquéu de rastrexadores d'anuncios
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Xestor de contraseñes
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Usu balanceáu de memoria
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Restola más rápido
+# Obsolete string
+features-index-firefox-product-benefits = Beneficios del productu { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Códigu llibre
+# Obsolete string
+features-index-were-always-transparent = Siempres somos tresparentes.
+# Obsolete string
+features-index-see-what-makes-us-different = Mira lo que mos estrema
+features-index-by-non-profit-mozilla = Por { -brand-name-mozilla }, ensin ánimu de llucru
+# Obsolete string
+features-index-protecting-the-health-of-the = Protexendo la salú d'internet.
+features-index-read-mozillas-mission = Llei la misión de { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Protexi los tos drechos
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Ayudamos a mantener controlaos los poderes corporativos.
+features-index-choose-independence = Escueyi independencia
+# Obsolete string
+features-index-limited-data-collection = Coleición de datos llendada
+features-index-opted-in-to-privacy-so-you = Optemos pola privacidá pa qu'asina pueas restolar llibre.
+features-index-read-our-privacy-policy = Llei la nuesa política de privacidá
+# Obsolete string
+features-index-more-private = Más priváu
+features-index-we-dont-sell-access-to-your = Nun vendemos l'accesu a los tos datos en llinia. Puntu pelota.
+features-index-get-firefox-for-privacy = Consigui { -brand-name-firefox } pola so privacidá

--- a/az/firefox/features/index.ftl
+++ b/az/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = { -brand-name-firefox } özəllikləriylə məxfiliyinizi qoruyun və daha sürətli gəzin
+# HTML page description
+features-index-youre-in-control-with-firefoxs = { -brand-name-firefox }-un istifadəsi asan məxfiliyinizi qoruyan və səyahəti sürətləndirən özəllikləri ilə idarədə qalın.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } özəllikləri
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Yeni { -brand-name-firefox } səyyahının özəllikləri ilə tanış olun
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Sevimli əlavələriniz və qoşmalarınız
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Səyyahınızı fərdiləşdirin
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Cihazlar arası sinxronlaşdırın
+# Obsolete string
+features-index-tabs-that-travel = Gəzən vərəqlər
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Daha yaxşı əlfəcinlər
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Daha güclü Məxfi Səyahət
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Reklam izləyicilərini əngəlləyin
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Şifrə İdarəçisi
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Tarazlaşdırılmış yaddaş istifadəsi
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Daha sürətli gəzin
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } işlətməyin üstünlükləri
+# Obsolete string
+features-index-open-source = Açıq qaynaq
+# Obsolete string
+features-index-were-always-transparent = Həmişə şəffafıq.
+# Obsolete string
+features-index-see-what-makes-us-different = Bizi fərqli edən şeyləri görün
+features-index-by-non-profit-mozilla = Qeyri-kommersial { -brand-name-mozilla }dan
+# Obsolete string
+features-index-protecting-the-health-of-the = İnternetin sağlamlığını qoruyuruq.
+features-index-read-mozillas-mission = { -brand-name-mozilla }nın missiyasını oxuyun
+# Obsolete string
+features-index-protect-your-rights = Hüquqlarınızı qoruyun
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Korporativ güclərin nəzarətdə qalmalarına kömək edirik.
+features-index-choose-independence = Müstəqilliyi seç
+# Obsolete string
+features-index-limited-data-collection = Limitləndirilmiş məlumat toplanması
+features-index-opted-in-to-privacy-so-you = Azad səyahətiniz üçün qoşulu məxfilik.
+features-index-read-our-privacy-policy = Məxfilik siyarətimizi oxuyun
+# Obsolete string
+features-index-more-private = Daha məxfi
+features-index-we-dont-sell-access-to-your = Onlayn məlumatlarınızı satmırıq. Nöqtə.
+features-index-get-firefox-for-privacy = Məxfilik üçün { -brand-name-firefox }-u endirin

--- a/azz/firefox/features/index.ftl
+++ b/azz/firefox/features/index.ftl
@@ -1,0 +1,56 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Xikonpaleui maj mitsonyekpialikan tein Internetkopa kiseliskej uan xikontatekiujti Internet okachi ijsiujka ika nepaleuilmej tein kipia { -brand-name-firefox }.
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Tiontayekantok ika nepaleuijlmej tein kipia { -brand-name-firefox } tein amo ouij tikontatekiujtis uan kipaleuiaj maj mitsonyekpialikan tein Internetkopa kiseliskej uan kichiuaj Internet maj okachi ijsiujka tekiti.
+# Hero title
+features-index-firefox-features = Inepaleuiluan { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Motamajsikayouan uan moextensiónuan tein tikonteluelita
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Xikonyekchiua monavegador kemej tikonkuisnekis
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Xikontekitilti Sync ika moteposuan
+# Obsolete string
+features-index-tabs-that-travel = Tel uejka xionyo uan xikonuika mopestañajuan
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Neskayomej marcadores itech Internet tein okachi kuali
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Nepaleuil maj se kitatekiujti Internet uan amo se mokuejmolo yejua okachi chikauak
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Maj moajchiuakan tanauatilmej tein tetoktiliaj
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Kampa se uelis kiyekanas ichtakatajkuilolmej
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Kitekitiltia taelnamikilis kemej moneki
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Xikontatekiujti Internet okachi ijsiujka
+# Obsolete string
+features-index-open-source = Tein se uelis mokuis tein amo tatsaktok
+# Obsolete string
+features-index-were-always-transparent = Tejuan nochipa tinaltoktik
+# Obsolete string
+features-index-see-what-makes-us-different = Xikonita keyej tejuan titataman kemej oksekin
+features-index-by-non-profit-mozilla = Tein amo kitemoua motomintis, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Maj se kipaleui Internet tein paktok.
+features-index-read-mozillas-mission = Xikonixtajtolti itekiuj { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Xikonmatampaui momelaujkatanauatiluan
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Tikpaleuijtokej motsinkixtiaj ininchikaujkauelilis uejueyitekitiloyamej.
+features-index-choose-independence = Xikonixpejpena tionmoixyekanas
+# Obsolete string
+features-index-limited-data-collection = Nechikolis ika datos tein kiixtalijkej
+features-index-opted-in-to-privacy-so-you = Tikixpejpenaj kiyekpiaskej tein kiseliskej, ijkon tionuelis tikontatekiujtis tatojtomal Internet.
+features-index-read-our-privacy-policy = Xikonixtajtolti totanemililis keniuj tikyekpiaj tein tikseliaj
+# Obsolete string
+features-index-more-private = Okachiok amo senteixtenoj
+features-index-we-dont-sell-access-to-your = Amo tiknamakaj maj kalakikan itech motajkuilolixnekayouan tein moajsij Internet. Tonalmej.
+features-index-get-firefox-for-privacy = Xikonajsi { -brand-name-firefox } ta kiyekpia tein kiselia

--- a/be/firefox/features/index.ftl
+++ b/be/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Ахоўвайце сваю прыватнасць і аглядайце хутчэй дзякуючы магчымасцям { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Вы кіруеце магчымасцямі { -brand-name-firefox }, якія ахоўваюць вашу прыватнасць і паскараюць агляданне.
+# Hero title
+features-index-firefox-features = Магчымасці { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Адкрыйце магчымасці абсалютна новага { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Вашы ўпадабаныя дадаткі і пашырэнні
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Уладкуйце свой браўзер
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Сінхранізуйцеся паміж прыладамі
+# Obsolete string
+features-index-tabs-that-travel = Карткі-падарожнікі
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Лепшыя закладкі
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Больш магутнае прыватнае агляданне
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Блакаванне рэкламнага сачэння
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Кіраўнік пароляў
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Збалансаванае выкарыстанне памяці
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Аглядайце хутчэй
+# Obsolete string
+features-index-firefox-product-benefits = Перавагі выкарыстання { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Адкрыты зыходны код
+# Obsolete string
+features-index-were-always-transparent = Мы заўжды празрыстыя.
+# Obsolete string
+features-index-see-what-makes-us-different = Даведайцеся, што робіць нас іншымі
+features-index-by-non-profit-mozilla = Ад некамерцыйнай { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Ахова здароўя інтэрнэту.
+features-index-read-mozillas-mission = Прачытаць місію { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Абараніце свае правы
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Мы дапамагаем стрымліваць моц карпарацый.
+features-index-choose-independence = Выберыце незалежнасць
+# Obsolete string
+features-index-limited-data-collection = Абмежаваны збор дадзеных
+features-index-opted-in-to-privacy-so-you = Прыватнасць уключана, так што вы можаце аглядаць вольна.
+features-index-read-our-privacy-policy = Прачытайце нашу палітыку прыватнасці
+# Obsolete string
+features-index-more-private = Больш прыватны
+features-index-we-dont-sell-access-to-your = Мы не гандлюем вашымі анлайн-дадзенымі. Кропка.
+features-index-get-firefox-for-privacy = Атрымайце { -brand-name-firefox } дзеля прыватнасці

--- a/bg/firefox/features/index.ftl
+++ b/bg/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Защитете вашата поверителност и разглеждайте по-бързо с възможностите на { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Вие държите контрола на възможности на { -brand-name-firefox }, които пазят вашата поверителност и скорост на разглеждане.
+# Hero title
+features-index-firefox-features = Възможности на { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Разберете за възможностите на напълно новия мрежов четец { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Вашите любими добавки и разширения
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Настройте вашия четец
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Синхронизирайте между устройства
+# Obsolete string
+features-index-tabs-that-travel = Раздели, копито са с вас навсякъде
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = По-добри отметки
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = По-мощно частно сърфиране
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Блокиране на рекламните тракери
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Управление на пароли
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Балансирано използване на паметта
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Разглеждайте по-бързо
+# Obsolete string
+features-index-firefox-product-benefits = Преимущества при използване на { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Отворен изходен код
+# Obsolete string
+features-index-were-always-transparent = Винаги сме прозрачни.
+# Obsolete string
+features-index-see-what-makes-us-different = Вижте защо сме различни
+features-index-by-non-profit-mozilla = От некомерсиална { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Защитаваме здравето на Мрежата.
+features-index-read-mozillas-mission = Прочетете мисията на { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Защита на вашите права
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Помагаме да държите корпорациите далеч.
+features-index-choose-independence = Изберете независимостта
+# Obsolete string
+features-index-limited-data-collection = Ограничено събиране на данни
+features-index-opted-in-to-privacy-so-you = Поверете се на мерките за сигурност, за да можете свободно да разглеждате.
+features-index-read-our-privacy-policy = Прочетете нашата политика за поверителност
+# Obsolete string
+features-index-more-private = Още по-лично
+features-index-we-dont-sell-access-to-your = Ние не продаваме достъп до вашите онлайн данни. Никога.
+features-index-get-firefox-for-privacy = Изполвайте { -brand-name-firefox } за сигурност

--- a/bn/firefox/features/index.ftl
+++ b/bn/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = { -brand-name-firefox } এর বৈশিষ্ট্যাবলী ব্যবহার করে আপনার গোপনীয়তা সুরক্ষিত রাখুন এবং দ্রুততার সাথে ব্রাউজ করুন
+# HTML page description
+features-index-youre-in-control-with-firefoxs = আপনি { -brand-name-firefox } এর সহজ বৈশিষ্ট্যাবলী ব্যবহার করে আপনার গোপনীয়তা এবং ব্রাউজ করা গতির নিয়ন্ত্রণে রয়েছেন।
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } এর বৈশিষ্ট্যাবলী
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = নতুন { -brand-name-firefox } ব্রাউজারের সব বৈশিষ্ট্যগুলো আবিষ্কার করুন
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = আপনার পছন্দের অ্যাড-অন ও এক্সটেনশন
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = আপনার ব্রাউজার কাস্টোমাইজ করুন
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = একাধিক ডিভাইসের মধ্যে সিঙ্ক করুন
+# Obsolete string
+features-index-tabs-that-travel = ট্যাব যা স্থান পরিবর্তন করাতে পারে
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = আরও ভাল বুকমার্ক
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = আরও শক্তিশালী ব্যক্তিগত ব্রাউজিং
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = এড ট্যাকার ব্লক
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = পাসওয়ার্ড ম্যানেজার
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = ব্যালেন্সড মেমরি ব্যবহার করুন
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = দ্রুততার সাথে ব্রাউজ করুন
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } প্রোডাক্ট এর সুবিধাসমুহ
+# Obsolete string
+features-index-open-source = ওপেন সোর্স
+# Obsolete string
+features-index-were-always-transparent = আমরা সবসময়ই স্বচ্ছ।
+# Obsolete string
+features-index-see-what-makes-us-different = দেখুন আমরা কেন অন্যদের থেকে আলাদা
+features-index-by-non-profit-mozilla = অ্যাবাণিজ্যিক প্রতিষ্ঠান, { -brand-name-mozilla } দ্বারা
+# Obsolete string
+features-index-protecting-the-health-of-the = ইন্টারনেটের সুরক্ষা প্রদান করা হচ্ছে।
+features-index-read-mozillas-mission = { -brand-name-mozilla } এর মিশন পড়ুন
+# Obsolete string
+features-index-protect-your-rights = আপনার অধিকার সুরক্ষিত রাখুন
+# Obsolete string
+features-index-we-help-keep-corporate-powers = আমরা কর্পোরেট ক্ষমতা নিয়ন্ত্রণে রাখতে সাহায্য করি।
+features-index-choose-independence = স্বাধীনতা বেছে নিন
+# Obsolete string
+features-index-limited-data-collection = সীমিত ডাটা সংগ্রহ
+features-index-opted-in-to-privacy-so-you = গোপনীয়তা বেছে নিয়েছেন, যাতে আপনি অবাধে ব্রাউজ করতে পারেন।
+features-index-read-our-privacy-policy = আমাদের গোপনীয়তার নীতি পড়ুন
+# Obsolete string
+features-index-more-private = আরো গোপনীয়তা
+features-index-we-dont-sell-access-to-your = আমরা আপনার অনলাইন ডাটার প্রবেশাধিকার বিক্রয় করি না। এবং এটাই শেষ কথা।
+features-index-get-firefox-for-privacy = গোপনীয়তার জন্য { -brand-name-firefox } ব্যবহার করুন

--- a/br/firefox/features/index.ftl
+++ b/br/firefox/features/index.ftl
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# Hero title
+features-index-firefox-features = Keweriusterioù firefox
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personelait ho merdeer
+# Obsolete string
+features-index-more-private = Muioc'h a vuhez prevez

--- a/bs/firefox/features/index.ftl
+++ b/bs/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Zaštitite vašu privatnost i pretražujte brže sa { -brand-name-firefox }om
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Vi upravljate { -brand-name-firefox } mogućnostima koje štite vašu privatnost i brzinu pretraživanja.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } mogućnosti
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Istražite mogućnosti od potpuno novog { -brand-name-firefox } pretraživača
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Vaši omiljeni dodaci i ekstenzije
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Prilagodite vaš pretraživač
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sinhronizujte između uređaja
+# Obsolete string
+features-index-tabs-that-travel = Tabovi koji putuju
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Bolje zabilješke
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Još moćnije privatno pretraživanje
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Bloker reklama
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Upravitelj lozinki
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Balansirano korištenje memorije
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Pretražujte brže
+# Obsolete string
+features-index-firefox-product-benefits = Prednosti { -brand-name-firefox }a
+# Obsolete string
+features-index-open-source = Otvoreni izvor
+# Obsolete string
+features-index-were-always-transparent = Mi smo uvijek transparentni.
+# Obsolete string
+features-index-see-what-makes-us-different = Pogledajte šta nas čini drugačijim
+features-index-by-non-profit-mozilla = Pod Mozillom, neprofitnom organizacijom
+# Obsolete string
+features-index-protecting-the-health-of-the = Mi štitimo zdravlje interneta.
+features-index-read-mozillas-mission = Pročitajte Mozillinu misiju
+# Obsolete string
+features-index-protect-your-rights = Zaštitite svoja prava
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Mi pomažemo zadržati korporacijske moći u šahu.
+features-index-choose-independence = Odaberite nezavisnost
+# Obsolete string
+features-index-limited-data-collection = Ograničeno prikupljanje podataka
+features-index-opted-in-to-privacy-so-you = Posvećeni privatnosti, tako da možete slobodno pretraživati.
+features-index-read-our-privacy-policy = Pročitajte našu policu privatnosti
+# Obsolete string
+features-index-more-private = Više privatan
+features-index-we-dont-sell-access-to-your = Ne prodajemo pristup vašim mrežnim podacima. Razdoblje.
+features-index-get-firefox-for-privacy = Preuzmite { -brand-name-firefox } za privatnost

--- a/ca/firefox/features/index.ftl
+++ b/ca/firefox/features/index.ftl
@@ -1,0 +1,51 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# Hero title
+features-index-firefox-features = Característiques del { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Exploreu les característiques del nou navegador { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Els vostres complements i extensions preferits
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personalitzeu el navegador
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincronitzeu entre dispositius
+# Obsolete string
+features-index-tabs-that-travel = Pestanyes que viatgen
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Adreces d'interès millors
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navegació privada més potent
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Bloqueig d'elements de seguiment de publicitat
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Gestor de contrasenyes
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Ús equilibrat de la memòria
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Navegueu més ràpid
+# Obsolete string
+features-index-firefox-product-benefits = Beneficis del producte { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Codi obert
+# Obsolete string
+features-index-were-always-transparent = Sempre som transparents.
+# Obsolete string
+features-index-see-what-makes-us-different = Vegeu allò que ens fa diferents
+features-index-by-non-profit-mozilla = Creat per { -brand-name-mozilla }, sense ànim de lucre
+features-index-read-mozillas-mission = Llegiu la missió de { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Protegiu els vostres drets
+features-index-choose-independence = Trieu la independència
+# Obsolete string
+features-index-limited-data-collection = Recollida de dades limitada
+features-index-read-our-privacy-policy = Llegiu la nostra política de privadesa
+# Obsolete string
+features-index-more-private = Més privat
+features-index-get-firefox-for-privacy = Instal·leu el { -brand-name-firefox } per millorar la privadesa

--- a/cak/firefox/features/index.ftl
+++ b/cak/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Tachajij ri awichinanem chuqa' anin katok pa k'amaya'l rik'in ri taq rub'anikil { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Rat atchajin awi' rik'in ri taq samaj man ek'ayew ta ye'okisäx richin ri { -brand-name-firefox }, ri nuchajij ri awichinaxik chuqa' ri ruchuqa' awokem pa k'amaya'l.
+# Hero title
+features-index-firefox-features = Taq rub'anikil { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Ke'atz'eta' ri taq rub'anikilri k'ak'a' { -brand-name-firefox } okik'amaya'l
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Ri ajowanel taq atz'aqat chuqa' taq ak'amal
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Tawichinaj ri akanob'al
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Ximojri'ïl chi kikojol taq okisaxel
+# Obsolete string
+features-index-tabs-that-travel = Taq ruwi', ri yeb'eyaj
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Ütziläj taq yaketal
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Ichinan okem pa K'amaya'l yalan nïm ruchuq'a'
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Kiq'atik kojqanik taq rutzijol
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Runuk'samajel ewan taq tzij
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Silan rokisaxik ri tzatzq'ob'äl
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Katok pa k'amaya'l aninäq
+# Obsolete string
+features-index-firefox-product-benefits = Taq rutzil ri { -brand-name-firefox } Tikojil
+# Obsolete string
+features-index-open-source = Jaqäl xe'el
+# Obsolete string
+features-index-were-always-transparent = Junelïk öj ch'ajch'ojri'ïl.
+# Obsolete string
+features-index-see-what-makes-us-different = Tatzu' ri nijalon qichin
+features-index-by-non-profit-mozilla = Ruma man ojqan ta ch'akoj, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Tichajïx ri raxnaqil k'amaya'l.
+features-index-read-mozillas-mission = Tisik'ïx ri taqel rutaqanem { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Ke'achajij ri taq ach'ojib'al
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Yojto'on richin yechajïx ri ajto'onelal taq nimamoloj.
+features-index-choose-independence = Tacha' chi at alajk'aslem
+# Obsolete string
+features-index-limited-data-collection = Q'aton kimolik taq tzij
+features-index-opted-in-to-privacy-so-you = Niqacha' ri ichinanem, richin chi jamäl yatok pa k'amaya'l.
+features-index-read-our-privacy-policy = Tasik'ij ri runa'ojil qichinanem
+# Obsolete string
+features-index-more-private = Yalan ichinan
+features-index-we-dont-sell-access-to-your = Man nik'ayij ta richin ye'ok chupam ri taq atzij pa k'amab'ey. Ruq'ijul.
+features-index-get-firefox-for-privacy = Tak'ulu' ri richinanem { -brand-name-firefox }

--- a/cs/firefox/features/index.ftl
+++ b/cs/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Chraňte své soukromí a prohlížejte rychleji s { -brand-name-firefox }em
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Díky jednoduše použitelným funkcím { -brand-name-firefox }u máte nad ochranou vlastního soukromí i nad rychlostí prohlížení kontrolu.
+# Hero title
+features-index-firefox-features = Funkce { -brand-name-firefox }u
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Prozkoumejte funkce úplně nového { -brand-name-firefox }u
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Vaše oblíbené doplňky a rozšíření
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Přizpůsobte si svůj prohlížeč
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synchronizace mezi zařízeními
+# Obsolete string
+features-index-tabs-that-travel = Panely, které cestují
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Lepší záložky
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Schopnější anonymní prohlížení
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blokování sledujících reklam
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Správce hesel
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Vyvážené využití paměti
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Prohlížejte rychleji
+# Obsolete string
+features-index-firefox-product-benefits = Výhody { -brand-name-firefox }u
+# Obsolete string
+features-index-open-source = S otevřeným zdrojovým kódem
+# Obsolete string
+features-index-were-always-transparent = Jsme vždy transparentní.
+# Obsolete string
+features-index-see-what-makes-us-different = V čem jsme rozdílní
+features-index-by-non-profit-mozilla = Od neziskové organizace { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Chráníme zdraví internetu.
+features-index-read-mozillas-mission = Přečtěte si o misi Mozilly
+# Obsolete string
+features-index-protect-your-rights = Chraňte svá práva
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Pomáháme udržovat velké společnosti pod kontrolou.
+features-index-choose-independence = Zvolte nezávislost
+# Obsolete string
+features-index-limited-data-collection = Omezený sběr dat
+features-index-opted-in-to-privacy-so-you = V bezpečí a v soukromí můžete prohlížet svobodně.
+features-index-read-our-privacy-policy = Přečtěte si naše prohlášení o zásadách ochrany osobních údajů.
+# Obsolete string
+features-index-more-private = Více soukromí
+features-index-we-dont-sell-access-to-your = Neprodáváme přístup k vašim online údajům. Tečka.
+features-index-get-firefox-for-privacy = Získejte { -brand-name-firefox } kvůli soukromí

--- a/cy/firefox/features/index.ftl
+++ b/cy/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Diogelwch eich preifatrwydd a phori'n gynt gyda nodweddion { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Chi sy'n rheoli gyda nodweddion hawdd eu defnyddio { -brand-name-firefox } sy'n diogelu eich preifatrwydd a'ch cyflymder pori.
+# Hero title
+features-index-firefox-features = Nodweddion { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Dyma nodweddion newydd { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Eich hoff ychwanegion ac estyniadau
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Cyfaddasu eich porwr
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Cydweddu rhwng dyfeisiau
+# Obsolete string
+features-index-tabs-that-travel = Tabiau sy'n teithio
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Gwell nodau tudalen
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Pori Preifat mwy pwerus
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Rhwystro tracwyr hysbysebion
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Rheolwr Cyfrinair
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Defnydd cof cytbwys
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Pori'n gynt
+# Obsolete string
+features-index-firefox-product-benefits = Manteision Cynnyrch { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Cod agored
+# Obsolete string
+features-index-were-always-transparent = Rydym bob amser yn dryloyw.
+# Obsolete string
+features-index-see-what-makes-us-different = Gweld beth sy'n gwneud ni'n wahanol
+features-index-by-non-profit-mozilla = Gan { -brand-name-mozilla }, dim-er-elw
+# Obsolete string
+features-index-protecting-the-health-of-the = Yn diogelu iechyd y rhyngrwyd.
+features-index-read-mozillas-mission = Darllenwch genhadaeth { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Diogelu eich hawliau
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Byddwn yn cadw grymoedd corfforaethol yn eu lle.
+features-index-choose-independence = Dewis annibyniaeth
+# Obsolete string
+features-index-limited-data-collection = Casglu data cyfyngedig
+features-index-opted-in-to-privacy-so-you = Rhag-ddewis preifatrwydd, fel bod modd i chi pori'n rhydd.
+features-index-read-our-privacy-policy = Darllenwch ei polisi preifatrwydd
+# Obsolete string
+features-index-more-private = Mwy preifat
+features-index-we-dont-sell-access-to-your = Nid ydym yn gwerthu mynediad i'ch data ar-lein. Byth.
+features-index-get-firefox-for-privacy = { -brand-name-firefox } ar gyfer eich preifatrwydd

--- a/da/firefox/features/index.ftl
+++ b/da/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Beskyt dit privatliv og surf hurtigere med { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Med { -brand-name-firefox }' funktioner til at beskytte dit privatliv og til at sætte fart på nettet, er det dig, der styrer.
+# Hero title
+features-index-firefox-features = Funktioner i { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Udforsk funktionerne i den helt nye { -brand-name-firefox }-browser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Dine foretrukne tilføjelser og udvidelser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Tilpas din browser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synkroniser mellem enheder
+# Obsolete string
+features-index-tabs-that-travel = Faneblade på farten
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Bedre bogmærker
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Mere effektiv privat browsing
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blokering af annoncesporing
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Håndtering af adgangskoder
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Tilpasset brug af hukommelse
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Surf hurtigere
+# Obsolete string
+features-index-firefox-product-benefits = Fordelene ved { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Open source
+# Obsolete string
+features-index-were-always-transparent = Vi går ind for åbenhed.
+# Obsolete string
+features-index-see-what-makes-us-different = Se hvad der gør os anderledes
+features-index-by-non-profit-mozilla = Lavet af nonprofit-organisationen { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Beskytter internettets sundhed.
+features-index-read-mozillas-mission = Læs om { -brand-name-mozilla }s mission
+# Obsolete string
+features-index-protect-your-rights = Beskyt dine rettigheder
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Vi hjælper med at holde styr på de kommercielle virksomheder.
+features-index-choose-independence = Vælg uafhængighed
+# Obsolete string
+features-index-limited-data-collection = Begrænset dataindsamling
+features-index-opted-in-to-privacy-so-you = Vi beskytter dit privatliv, så du kan surfe frit.
+features-index-read-our-privacy-policy = Læs vores privatlivspolitik
+# Obsolete string
+features-index-more-private = Mere privat
+features-index-we-dont-sell-access-to-your = Vi sælger ikke adgang til dine online-data. Punktum.
+features-index-get-firefox-for-privacy = Beskyt privatlivet

--- a/de/firefox/features/index.ftl
+++ b/de/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = { -brand-name-firefox } Features für noch mehr Privatsphäre und Geschwindigkeit
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Du behälst bei { -brand-name-firefox } die Kontrolle – mit den Features für Privatsphäre und schnelleres Surfen.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } Features
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Entdecke jetzt die Features vom neuen { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Deine Erweiterungen
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Deine Themes
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synchron auf allen Geräten
+# Obsolete string
+features-index-tabs-that-travel = Deine Tabs mitnehmen
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Deine Lesezeichen im Griff
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Dein Privater Modus
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Dein Werbe-Tracker-Blocker
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Dein Passwort-Manager
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Dein Speicher freut sich
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Schneller surfen
+# Obsolete string
+features-index-firefox-product-benefits = Vorteile von { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Open Source in unserer DNA
+# Obsolete string
+features-index-were-always-transparent = Wir sind immer transparent.
+# Obsolete string
+features-index-see-what-makes-us-different = Was uns unterscheidet
+features-index-by-non-profit-mozilla = Non-Profit aus Überzeugung
+# Obsolete string
+features-index-protecting-the-health-of-the = Wir machen uns für ein gesundes Netz stark.
+features-index-read-mozillas-mission = Was uns antreibt
+# Obsolete string
+features-index-protect-your-rights = Schutz für Deine Rechte
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Wir stellen uns gegen mächtige Konzerne.
+features-index-choose-independence = Setze auf Unabhängigkeit
+# Obsolete string
+features-index-limited-data-collection = Datensparsamkeit
+features-index-opted-in-to-privacy-so-you = Unser Datenschutz immer mit an Bord, damit Du umso freier surfen kannst.
+features-index-read-our-privacy-policy = Datenschutz bei Mozilla
+# Obsolete string
+features-index-more-private = Das Plus an Privatsphäre
+features-index-we-dont-sell-access-to-your = Wir verkaufen keine Nutzerdaten. Basta.
+features-index-get-firefox-for-privacy = Hole Dir das Extra an Privatsphäre

--- a/dsb/firefox/features/index.ftl
+++ b/dsb/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Šćitajśo swóju priwatnosć a pśeglědujśo malsnjej z funkcijami { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Maśo kontrolu nad lažko wužywajobnymi funkcijami { -brand-name-firefox }, kótarež wašu priwatnosć šćitaju a nad malsnosću pśeglědowanja.
+# Hero title
+features-index-firefox-features = Funkcije { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Wuslěźćo funkcije nowučkego wobglědowaka { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Waše nejlubše dodanki a rozšyrjenja
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Pśiměŕśo swój wobglědowak
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synchronizěrujśo mjazy rědami
+# Obsolete string
+features-index-tabs-that-travel = Rejtariki za sobuwześe
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Lěpše cytańske znamjenja
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Mócnjejšy priwatny modus
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blokěrowanje wabjeńskego slědowanja
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Zastojnik gronidłow
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Wurownane składowe wužyśe
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Malsnjej pśeglědowaś
+# Obsolete string
+features-index-firefox-product-benefits = Lěpšyny { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Wótwórjone žrědło
+# Obsolete string
+features-index-were-always-transparent = Smy pśecej transparentne.
+# Obsolete string
+features-index-see-what-makes-us-different = Glědajśo, což nas rozeznawa
+features-index-by-non-profit-mozilla = Wót { -brand-name-mozilla }, za wše wužytneje organizacije
+# Obsolete string
+features-index-protecting-the-health-of-the = Šćita strowosć interneta.
+features-index-read-mozillas-mission = Cytajśo wó misiji { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Šćitajśo swóje pšawa
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Pomagamy mócne pśedewześa pód kontrolu źaržaś.
+features-index-choose-independence = Rozsuźćo se za njewótwisnosć
+# Obsolete string
+features-index-limited-data-collection = Wobgrancowane gromaźenje datow
+features-index-opted-in-to-privacy-so-you = Pó standarźe z priwatnosću, aby wy mógł licho pśeglědowaś.
+features-index-read-our-privacy-policy = Cytajśo naše pšawidła priwatnosći
+# Obsolete string
+features-index-more-private = Priwatnjejšy
+features-index-we-dont-sell-access-to-your = Pśistup k wašym datam online njepśedawamy. Dypk.
+features-index-get-firefox-for-privacy = Wěcej priwatnosći pśez { -brand-name-firefox }

--- a/el/firefox/features/index.ftl
+++ b/el/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Προστατέψτε το απόρρητό σας και περιηγηθείτε γρηγορότερα με τις λειτουργίες του { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Έχετε τον απόλυτο έλεγχο με τις εύκολες στη χρήση λειτουργίες του { -brand-name-firefox } που προστατεύουν το απόρρητό σας και επιταχύνουν την περιήγησή σας.
+# Hero title
+features-index-firefox-features = Χαρακτηριστικά του { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Εξερευνήστε τις λειτουργίες του ολοκαίνουριου { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Τα αγαπημένα σας πρόσθετα και επεκτάσεις
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Προσαρμόστε το πρόγραμμα περιήγησής σας
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Συγχρονισμός ανάμεσα σε συσκευές
+# Obsolete string
+features-index-tabs-that-travel = Καρτέλες που ταξιδεύουν
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Καλύτεροι σελιδοδείκτες
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Πιο ισχυρή ιδιωτική περιήγηση
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Φραγή διαφημιστικών ιχνηλατών
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Διαχείριση κωδικών πρόσβασης
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Ισορροπημένη χρήση μνήμης
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Περιηγηθείτε πιο γρήγορα
+# Obsolete string
+features-index-firefox-product-benefits = Οφέλη των προϊόντων { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Ανοικτού κώδικα
+# Obsolete string
+features-index-were-always-transparent = Είμαστε πάντα διαφανείς.
+# Obsolete string
+features-index-see-what-makes-us-different = Δείτε τι μάς διαφοροποιεί
+features-index-by-non-profit-mozilla = Από την μη κερδοσκοπική { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Προστασία της υγείας του διαδικτύου.
+features-index-read-mozillas-mission = Διαβάστε την αποστολή της { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Προστατέψτε τα δικαιώματά σας
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Διατηρούμε τις εταιρικές δυνάμεις υπό έλεγχο.
+features-index-choose-independence = Επιλέξτε την ανεξαρτησία
+# Obsolete string
+features-index-limited-data-collection = Περιορισμένη συλλογή δεδομένων
+features-index-opted-in-to-privacy-so-you = Υποστηρίζουμε την ιδιωτικότητα, ώστε να μπορείτε να περιηγήστε ελεύθερα.
+features-index-read-our-privacy-policy = Διαβάστε την πολιτική απορρήτου μας
+# Obsolete string
+features-index-more-private = Πιο ιδιωτικό
+features-index-we-dont-sell-access-to-your = Δεν πωλούμε την πρόσβαση στα διαδικτυακά σας δεδομένα. Τελεία και παύλα.
+features-index-get-firefox-for-privacy = Αποκτήστε το { -brand-name-firefox } για ιδιωτικότητα

--- a/en-CA/firefox/features/index.ftl
+++ b/en-CA/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protect your privacy and browse faster with { -brand-name-firefox } features
+# HTML page description
+features-index-youre-in-control-with-firefoxs = You’re in control with { -brand-name-firefox }’s easy-to-use features that protect your privacy and browsing speeds.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } features
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Explore the features of the all new { -brand-name-firefox } browser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Your favourite add-ons and extensions
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Customize your browser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synchronize between devices
+# Obsolete string
+features-index-tabs-that-travel = Tabs that travel
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Better bookmarks
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = More powerful Private Browsing
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Ad tracker blocking
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Password Manager
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Balanced memory usage
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Browse faster
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } Product Benefits
+# Obsolete string
+features-index-open-source = Open source
+# Obsolete string
+features-index-were-always-transparent = We’re always transparent.
+# Obsolete string
+features-index-see-what-makes-us-different = See what makes us different
+features-index-by-non-profit-mozilla = By non-profit, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Protecting the health of the internet.
+features-index-read-mozillas-mission = Read { -brand-name-mozilla }’s mission
+# Obsolete string
+features-index-protect-your-rights = Protect your rights
+# Obsolete string
+features-index-we-help-keep-corporate-powers = We help keep corporate powers in check.
+features-index-choose-independence = Choose independence
+# Obsolete string
+features-index-limited-data-collection = Limited data collection
+features-index-opted-in-to-privacy-so-you = Opted-in to privacy, so you can browse freely.
+features-index-read-our-privacy-policy = Read our privacy policy
+# Obsolete string
+features-index-more-private = More private
+features-index-we-dont-sell-access-to-your = We don’t sell access to your online data. Period.
+features-index-get-firefox-for-privacy = Get { -brand-name-firefox } for privacy

--- a/en-GB/firefox/features/index.ftl
+++ b/en-GB/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protect your privacy and browse faster with { -brand-name-firefox } features
+# HTML page description
+features-index-youre-in-control-with-firefoxs = You’re in control with { -brand-name-firefox }’s easy-to-use features that protect your privacy and browsing speeds.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } features
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Explore the features of the all new { -brand-name-firefox } browser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Your favourite add-ons and extensions
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Customise your browser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synchronise between devices
+# Obsolete string
+features-index-tabs-that-travel = Tabs that travel
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Better bookmarks
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = More powerful Private Browsing
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Ad tracker blocking
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Password Manager
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Balanced memory usage
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Browse faster
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } Product Benefits
+# Obsolete string
+features-index-open-source = Open source
+# Obsolete string
+features-index-were-always-transparent = We’re always transparent.
+# Obsolete string
+features-index-see-what-makes-us-different = See what makes us different
+features-index-by-non-profit-mozilla = By non-profit, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Protecting the health of the internet.
+features-index-read-mozillas-mission = Read { -brand-name-mozilla }’s mission
+# Obsolete string
+features-index-protect-your-rights = Protect your rights
+# Obsolete string
+features-index-we-help-keep-corporate-powers = We help keep corporate powers in check.
+features-index-choose-independence = Choose independence
+# Obsolete string
+features-index-limited-data-collection = Limited data collection
+features-index-opted-in-to-privacy-so-you = Opted-in to privacy, so you can browse freely.
+features-index-read-our-privacy-policy = Read our privacy policy
+# Obsolete string
+features-index-more-private = More private
+features-index-we-dont-sell-access-to-your = We don’t sell access to your online data. Period.
+features-index-get-firefox-for-privacy = Get { -brand-name-firefox } for privacy

--- a/en/firefox/features/index.ftl
+++ b/en/firefox/features/index.ftl
@@ -1,0 +1,114 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protect your privacy and browse faster with { -brand-name-firefox } features
+
+# HTML page description
+features-index-youre-in-control-with-firefoxs = You’re in control with { -brand-name-firefox }’s easy-to-use features that protect your privacy and browsing speeds.
+
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } features
+
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Explore the features of the all new { -brand-name-firefox } browser
+
+# Updated string
+features-index-firefox-is-fast = { -brand-name-firefox } is the fast, lightweight, privacy-focused browser that works across all your devices.
+
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Your favorite add-ons and extensions
+features-index-add-powerful-functions = Add powerful functions, useful features and even a little fun to your Firefox browser.
+features-index-see-all = See all extensions
+
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Customize your browser
+features-index-give-your-browser = Give your browser the look you want  with thousands of different themes.
+
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sync between devices
+features-index-important-stuff = Make sure all your important stuff — internet searches, passwords, open tabs — appears where you need it on every device.
+features-index-get-an-account = Get a { -brand-name-firefox-account }
+
+# Obsolete string
+features-index-tabs-that-travel = Tabs that travel
+
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Better bookmarks
+features-index-use-the-bookmark = Use the bookmark star icon to stay organized and add custom names and folders quickly.
+features-index-from-the-company = From a company that puts people before profit
+
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = More powerful Private Browsing
+features-index-private-browsing-mode = Private Browsing mode deletes cookie data and your browsing history every time you close it.
+
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Ad tracker blocking
+features-index-firefox-automatically = { -brand-name-firefox } automatically blocks 2000+ ad trackers from following you around the internet.
+
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Password Manager
+features-index-access-all-passwords = { -brand-name-firefox-lockwise } lets you access all the passwords you’ve saved in Firefox — and it’s free.
+
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Balanced memory usage
+features-index-just-enough = { -brand-name-firefox } uses just enough memory to create a smooth experience so your computer stays responsive to other tasks.
+
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Browse faster
+features-index-use-less-memory = { -brand-name-firefox } uses less memory than { -brand-name-chrome }, so your other programs can keep running at top speed.
+
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } Product Benefits
+
+# Obsolete string
+features-index-open-source = Open source
+
+# Updated string
+features-index-open-source-minds = Open source. Open minds.
+features-index-mozilla-creates = { -brand-name-mozilla } creates powerful web tech for everyone.
+
+# Obsolete string
+features-index-were-always-transparent = We’re always transparent.
+
+# Obsolete string
+features-index-see-what-makes-us-different = See what makes us different
+features-index-by-non-profit-mozilla = By non-profit, { -brand-name-mozilla }
+features-index-on-a-mission = On a mission to keep the internet open and accessible to all.
+features-index-keep-corporate-power = Keep corporate power in check
+features-index-independent-browser = { -brand-name-firefox } is the only major independent browser.
+
+# Obsolete string
+features-index-protecting-the-health-of-the = Protecting the health of the internet.
+features-index-read-mozillas-mission = Read { -brand-name-mozilla }’s mission
+
+# Obsolete string
+features-index-protect-your-rights = Protect your rights
+
+# Obsolete string
+features-index-we-help-keep-corporate-powers = We help keep corporate powers in check.
+features-index-choose-independence = Choose independence
+
+# Obsolete string
+features-index-limited-data-collection = Limited data collection
+features-index-opted-in-to-privacy-so-you = Opted-in to privacy, so you can browse freely.
+features-index-read-our-privacy-policy = Read our privacy policy
+
+# Obsolete string
+features-index-more-private = More private
+
+# Updated string
+features-index-private-by-default = Private by default
+features-index-enhanced-tracking = Enhanced tracking protection
+features-index-we-dont-sell-access-to-your = We don’t sell access to your online data. Period.
+features-index-get-firefox-for-privacy = Get { -brand-name-firefox } for privacy
+features-index-firefox-vs = { -brand-name-firefox } vs. other browsers
+features-index-stack-up = See how { -brand-name-firefox } stacks up against other popular browsers.
+features-index-compare-browsers = Compare browsers
+features-index-see-themes = See top themes
+features-index-download-latest = Download the latest { -brand-name-firefox }

--- a/eo/firefox/features/index.ftl
+++ b/eo/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protektu vian privatecon kaj retumu pli rapide per la trajtoj de { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Per la facile uzeblaj trajtoj de { -brand-name-firefox }, kiuj protektas vian privatecon kaj akcelas vian retumon, vi estas la reganto.
+# Hero title
+features-index-firefox-features = Trajtoj de { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Esploru la trajtojn de la tute nova { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Viaj plej ŝatataj aldonaĵoj kaj etendaĵoj
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personecigu vian retumilon
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Speguli inter aparatoj
+# Obsolete string
+features-index-tabs-that-travel = Vojaĝigu viajn langetojn
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Plibonigitaj legosignoj
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Pli pova privata retumo
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blokado de reklamaj spuriloj
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Administranto de pasvortoj
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Ekvilibra memoruzo
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Retumu pli rapide
+# Obsolete string
+features-index-firefox-product-benefits = Avantaĝoj de { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Malfermitkoda
+# Obsolete string
+features-index-were-always-transparent = Ni ĉiam estas travideblaj.
+# Obsolete string
+features-index-see-what-makes-us-different = Vidu tion, kio igas nin apartaj
+features-index-by-non-profit-mozilla = Farita de neproficela organizo: { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Ni protektas la bonfaron de interreto.
+features-index-read-mozillas-mission = Legu la mision de { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Protektu viajn rajtojn
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Ni helpas eviti ke korporacioj translimiĝu.
+features-index-choose-independence = Elektu sendependecon
+# Obsolete string
+features-index-limited-data-collection = Limigita kolekto de datumoj
+features-index-opted-in-to-privacy-so-you = Retumu senzorge, via privateco estas norme protektata.
+features-index-read-our-privacy-policy = Legu nian politikon pri privateco
+# Obsolete string
+features-index-more-private = Pli privata
+features-index-we-dont-sell-access-to-your = Ni ne vendas aliron al viaj retaj datumoj. Punkto.
+features-index-get-firefox-for-privacy = Ricevu { -brand-name-firefox } por havi pli da privateco

--- a/es-AR/firefox/features/index.ftl
+++ b/es-AR/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protegé tu privacidad y navegá más rápido con las funcionalidades de { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Con las sencillas características de { -brand-name-firefox } que protegen tu privacidad y velocidad de navegación, tenés el control.
+# Hero title
+features-index-firefox-features = Características de { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Explorá las características del nuevo navegador { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Tus complementos y extensiones favoritas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personalizá tu navegador
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincronizá dispositivos
+# Obsolete string
+features-index-tabs-that-travel = Pestañas que viajan
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Mejores marcadores
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navegación privada mas poderosa
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Bloqueo de publicidad con rastreadores
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Administrador de contraseñas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Uso balanceado de la memoria
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Navegá más rápido
+# Obsolete string
+features-index-firefox-product-benefits = Beneficios de { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Código abierto
+# Obsolete string
+features-index-were-always-transparent = Somos siempre transparentes.
+# Obsolete string
+features-index-see-what-makes-us-different = Mirá qué nos hace diferentes
+features-index-by-non-profit-mozilla = De { -brand-name-mozilla }, sin fines de lucro
+# Obsolete string
+features-index-protecting-the-health-of-the = Proteger la salud de Internet.
+features-index-read-mozillas-mission = Leé sobre la misión de { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Protegé tus derechos
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Ayudamos a mantener las corporaciones bajo control.
+features-index-choose-independence = Elegí independencia
+# Obsolete string
+features-index-limited-data-collection = Limitada recolección de datos
+features-index-opted-in-to-privacy-so-you = Opciones de privacidad para que puedas navegar libremente.
+features-index-read-our-privacy-policy = Lee nuestra política de privacidad
+# Obsolete string
+features-index-more-private = Más privado
+features-index-we-dont-sell-access-to-your = No vendemos el acceso a tus datos en línea. Punto.
+features-index-get-firefox-for-privacy = Descargá { -brand-name-firefox } para tu privacidad

--- a/es-CL/firefox/features/index.ftl
+++ b/es-CL/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protege tu privacidad y navega más rápido con las características de { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Tú estas al control con las características de fácil uso de { -brand-name-firefox } que protegen tu privacidad y velocidad de navegación.
+# Hero title
+features-index-firefox-features = Características de { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Explora las funciones del nuevo navegador { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Tus complementos y extensiones favoritos
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personaliza tu navegador
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincroniza entre dispositivos
+# Obsolete string
+features-index-tabs-that-travel = Pestañas que viajan
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Mejores marcadores
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navegación privada más potente
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Bloqueo de rastreadores de publicidad
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Administrador de contraseñas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Uso balanceado de memoria
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Navega más rápido
+# Obsolete string
+features-index-firefox-product-benefits = Beneficios del producto { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Código abierto
+# Obsolete string
+features-index-were-always-transparent = Siempre somos transparentes.
+# Obsolete string
+features-index-see-what-makes-us-different = Mira lo que nos hace diferentes
+features-index-by-non-profit-mozilla = Por { -brand-name-mozilla }, sin fines de lucro
+# Obsolete string
+features-index-protecting-the-health-of-the = Protegiendo la salud de Internet.
+features-index-read-mozillas-mission = Lee la misión de { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Protege tus derechos
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Ayudamos a mantener las corporaciones bajo control.
+features-index-choose-independence = Elige ser independiente
+# Obsolete string
+features-index-limited-data-collection = Recolección de datos limitada
+features-index-opted-in-to-privacy-so-you = Optamos por la privacidad, por lo que puedes navegar libremente.
+features-index-read-our-privacy-policy = Lee nuestra política de privacidad
+# Obsolete string
+features-index-more-private = Más privado
+features-index-we-dont-sell-access-to-your = No vendemos acceso a tus datos en línea. Punto.
+features-index-get-firefox-for-privacy = Obtén { -brand-name-firefox } para privacidad

--- a/es-ES/firefox/features/index.ftl
+++ b/es-ES/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protege tu privacidad y navega más rápido con las características de { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Tú tienes el control con las características de { -brand-name-firefox } que protegen tu privacidad y tu velocidad de navegación.
+# Hero title
+features-index-firefox-features = Características de { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Descubre las características del nuevo { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Tus complementos y extensiones favoritos
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personaliza tu navegador
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincroniza entre dispositivos
+# Obsolete string
+features-index-tabs-that-travel = Pestañas que viajan
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Mejores marcadores
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navegación privada más potente
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Bloqueo de rastreadores de publicidad
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Administrador de contraseñas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Uso de memoria equilibrado
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Navega más rápido
+# Obsolete string
+features-index-firefox-product-benefits = Beneficios de los productos de { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Código abierto
+# Obsolete string
+features-index-were-always-transparent = Siempre somos transparentes.
+# Obsolete string
+features-index-see-what-makes-us-different = Mira lo que nos hace diferentes
+features-index-by-non-profit-mozilla = Por { -brand-name-mozilla }, sin ánimo de lucro
+# Obsolete string
+features-index-protecting-the-health-of-the = Protección de la salud de Internet.
+features-index-read-mozillas-mission = Lee la misión de { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Protege tus derechos
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Ayudamos a controlar los poderes corporativos.
+features-index-choose-independence = Elige ser independiente
+# Obsolete string
+features-index-limited-data-collection = Limitada recolección de datos
+features-index-opted-in-to-privacy-so-you = Privacidad incluida, para que navegues con libertad.
+features-index-read-our-privacy-policy = Lee nuestra política de privacidad
+# Obsolete string
+features-index-more-private = Más privado
+features-index-we-dont-sell-access-to-your = No vendemos acceso a tus datos en línea. Punto.
+features-index-get-firefox-for-privacy = Obtén { -brand-name-firefox } por su privacidad

--- a/es-MX/firefox/features/index.ftl
+++ b/es-MX/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protege tu privacidad y navega más rápido con las características de { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Tú estás en control con características fáciles de usar que protegen tu privacidad y la velocidad de navegación.
+# Hero title
+features-index-firefox-features = Características de { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Descubre las características del nuevo { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Tus complementos y extensiones favoritos
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personalizar tu navegador
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincronización entre dispositivos
+# Obsolete string
+features-index-tabs-that-travel = Viaja con tus pestañas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Mejores marcadores
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navegación privada más poderosa
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Bloqueo de rastreador de publicidad
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Administrador de contraseñas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Uso de memoria balanceado
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Navega más rápido
+# Obsolete string
+features-index-firefox-product-benefits = Beneficios de los productos de { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Código abierto
+# Obsolete string
+features-index-were-always-transparent = Siempre somos transparentes.
+# Obsolete string
+features-index-see-what-makes-us-different = Mira lo que nos hace diferentes
+features-index-by-non-profit-mozilla = Hecho por { -brand-name-mozilla }, una organización sin fines de lucro
+# Obsolete string
+features-index-protecting-the-health-of-the = Proteger la salud del Internet.
+features-index-read-mozillas-mission = Leer la misión de { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Protege tus derechos
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Ayudamos a mantener bajo control el poder de los corporativos.
+features-index-choose-independence = Escoge l'independencia
+# Obsolete string
+features-index-limited-data-collection = Recolección de datos limitada
+features-index-opted-in-to-privacy-so-you = Escoge la privacidad para que puedas navegar con más libertad.
+features-index-read-our-privacy-policy = Lee nuestra política de privacidad
+# Obsolete string
+features-index-more-private = Más privado
+features-index-we-dont-sell-access-to-your = Nosotros no vendemos acceso a tus datos en línea. Punto y final.
+features-index-get-firefox-for-privacy = Obtén { -brand-name-firefox } para más privacidad

--- a/et/firefox/features/index.ftl
+++ b/et/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Kaitse oma privaatsust ja sirvi veebi kiiremini { -brand-name-firefox }i võimaluste abil
+# HTML page description
+features-index-youre-in-control-with-firefoxs = { -brand-name-firefox }i kergesti kasutatavate võimalustega, mis sinu privaatsust ning veebilehitsemise kiirust kaitsevad, kontrollid olukorda sina.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox }i võimalused
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Avasta täiesti uue { -brand-name-firefox }i võimalused
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Sinu lemmikud lisad ja laiendused
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Veebilehitseja kohandamine
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Seadmete vaheline sünkroonimine
+# Obsolete string
+features-index-tabs-that-travel = Reisivad kaardid
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Paremad järjehoidjad
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Võimsam privaatne veebilehitsemine
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Reklaamijälitajate blokkimine
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Paroolihaldur
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Tasakaalustatud mälukasutus
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Kiirem veebilehitsemine
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox }i eelised
+# Obsolete string
+features-index-open-source = Avatud lähtekood
+# Obsolete string
+features-index-were-always-transparent = Oleme alati läbipaistvad.
+# Obsolete string
+features-index-see-what-makes-us-different = Vaata, mis meid teistest eristab
+features-index-by-non-profit-mozilla = Mittetulunduslik { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Kaitseme interneti tervist.
+features-index-read-mozillas-mission = Loe { -brand-name-mozilla } missiooni
+# Obsolete string
+features-index-protect-your-rights = Kaitseme sinu õigusi
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Hoiame korporatiivsed huvid kontrolli all.
+features-index-choose-independence = Vali sõltumatus
+# Obsolete string
+features-index-limited-data-collection = Piiratud andmete kogumine
+features-index-opted-in-to-privacy-so-you = Vaikimisi privaatne, et saaksid veebi vabalt lehitseda.
+features-index-read-our-privacy-policy = Loe meie privaatsuspoliitikat
+# Obsolete string
+features-index-more-private = Privaatsem
+features-index-we-dont-sell-access-to-your = Me ei müü ligipääsu sinu veebikasutuse andmetele. Jutul lõpp.
+features-index-get-firefox-for-privacy = Hangi privaatsuse nimel { -brand-name-firefox }

--- a/eu/firefox/features/index.ftl
+++ b/eu/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Babestu zure pribatutasuna eta nabigatu bizkorrago { -brand-name-firefox }en eginbideekin
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Pribatutasuna babestu eta nabigazioa bizkortzen duten { -brand-name-firefox }en eginbide erabilerrazekin, zeuk duzu kontrola.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox }en eginbideak
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Arakatu { -brand-name-firefox } nabigatzaile berrienaren eginbideak
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Zure gehigarri eta hedapen gogokoenak
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Pertsonalizatu nabigatzailea
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sinkronizatu gailuen artean
+# Obsolete string
+features-index-tabs-that-travel = Bidaiatzen duten fitxak
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Laster-marka hobeak
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Nabigazio pribatu boteretsuagoa
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Iragarkietako jarraipen-elementuen blokeoa
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Pasahitz-kudeatzailea
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Memoriaren erabilera orekatua
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Nabigatu bizkorrago
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } produktuen onurak
+# Obsolete string
+features-index-open-source = Kode irekikoa
+# Obsolete string
+features-index-were-always-transparent = Beti gara gardenak.
+# Obsolete string
+features-index-see-what-makes-us-different = Ikusi zerk desberdintzen gaituen
+features-index-by-non-profit-mozilla = Irabazi-asmorik gabeko { -brand-name-mozilla }ren eskutik
+# Obsolete string
+features-index-protecting-the-health-of-the = Interneten osasuna babestuz.
+features-index-read-mozillas-mission = Irakurri { -brand-name-mozilla }ren misioa
+# Obsolete string
+features-index-protect-your-rights = Babestu zure eskubideak
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Korporazioen indarra mugatzen laguntzen dugu.
+features-index-choose-independence = Aukeratu independentzia
+# Obsolete string
+features-index-limited-data-collection = Datu bilduma mugatua
+features-index-opted-in-to-privacy-so-you = Pribatua defektuz, libreki nabiga dezazun.
+features-index-read-our-privacy-policy = Irakurri gure pribatutasun-politika
+# Obsolete string
+features-index-more-private = Pribatuagoa
+features-index-we-dont-sell-access-to-your = Ez ditugu zure lineako datuak saltzen. Puntu.
+features-index-get-firefox-for-privacy = Eskuratu { -brand-name-firefox } pribatutasunerako

--- a/fa/firefox/features/index.ftl
+++ b/fa/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = با ویژگی‌های فایرفاکس مرور سریعتری داشته باشید و از حریم‌شخصی خود محافظت کنید
+# HTML page description
+features-index-youre-in-control-with-firefoxs = با ویژگی‌های با استفاده آسان فایرفاکس شما حریم‌شخصی و سرعت مرور خود را کنترل می‌کنید.
+# Hero title
+features-index-firefox-features = ویژگی‌های فایرفاکس
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = کشف ویژگی‌های مرورگر کاملا جدید فایرفاکس
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = افزودنی‌ها و افزونه‌های مورد علاقهٔ شما
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = مرورگر خود را شخصی‌سازی کنید
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = دستگاه‌ها را همگام‌سازی کنید
+# Obsolete string
+features-index-tabs-that-travel = زبانه‌هایی که سفر می‌کنند
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = نشانک‌های بهتر
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = مرور خصوصی قدرتمندتر
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = مسدود کردن ردیاب آگهی
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = مدیر گذرواژه
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = مصرف حافظه رایانه خود را متعادل کنید
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = سریع‌تر مرور کنید
+# Obsolete string
+features-index-firefox-product-benefits = مزایای محصول فایرفاکس
+# Obsolete string
+features-index-open-source = متن باز
+# Obsolete string
+features-index-were-always-transparent = ما همیشه شفاف هستیم.
+# Obsolete string
+features-index-see-what-makes-us-different = ببینید چه چیزی ما را متفاوت می‌کند
+features-index-by-non-profit-mozilla = توسط بنیاد غیر انتفاعی، موزیلا
+# Obsolete string
+features-index-protecting-the-health-of-the = حفاظت از سلامت اینترنت.
+features-index-read-mozillas-mission = ماموریت موزیلا را مطالعه کنید
+# Obsolete string
+features-index-protect-your-rights = از حقوق خود محافظت کنید
+# Obsolete string
+features-index-we-help-keep-corporate-powers = ما کمک می‌کنیم قدرت شرکت‌ها تحت نظارت بماند.
+features-index-choose-independence = استقلال را انتخاب کنید
+# Obsolete string
+features-index-limited-data-collection = جمع‌آوری اطلاعات محدود
+features-index-opted-in-to-privacy-so-you = انتخاب شده برای حریم خصوصی، پس می‌توانید آزادانه مرور کنید.
+features-index-read-our-privacy-policy = سیاست حریم خصوصی ما را مطالعه کنید
+# Obsolete string
+features-index-more-private = خصوصی‌تر
+features-index-we-dont-sell-access-to-your = ما دسترسی به اطلاعات شما را نمی‌فروشیم. ختم کلام.
+features-index-get-firefox-for-privacy = برای حریم شخصی فایرفاکس را دریافت کنید

--- a/ff/firefox/features/index.ftl
+++ b/ff/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Reen sutoro maa kadi wanngoro no yaawiri e fannuuji { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Ko aan jogii ɗowgol e fannuuji { -brand-name-firefox } beeɓɗi huutoraade deenooji suturo maa kam e jaawgol banngogol maa.
+# Hero title
+features-index-firefox-features = Fannuuji { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Yiylo fannuuji ɗi wanngorde firefox hesere pul ndee
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Ɓeyditte maa katojinaaɗe e timmitte
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Heertin wanngorde maa
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Jahdingol hakkunde kaɓirɗi
+# Obsolete string
+features-index-tabs-that-travel = Tabbe ɗannotooɗe
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Maantore ɓurorɗe
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Banngogol Suturo ɓurngol heewde doole
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Palogol ndewindorɗe ɓaŋŋine
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Toppitorde Finnde
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Kuutorogol teskorde ɓurondirngol
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Wanngo ko ɓuri yaawde
+# Obsolete string
+features-index-firefox-product-benefits = Ɓure Topirɗe { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Keɓe udditiiɗe
+# Obsolete string
+features-index-were-always-transparent = Ko min rewɓe laawol ñande kala.
+# Obsolete string
+features-index-see-what-makes-us-different = Yiy ko seerndi min e ko heddii
+features-index-by-non-profit-mozilla = Ko { -brand-name-mozilla } mo yoɓetaake
+# Obsolete string
+features-index-protecting-the-health-of-the = Deengol cellal enternet ngal.
+features-index-read-mozillas-mission = Tar darnde { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Reen jojjanɗe maa
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Ha min mballa reende mbaawka julaŋkooɓe.
+features-index-choose-independence = Suɓo heɓde hoore maa
+# Obsolete string
+features-index-limited-data-collection = Ƴettugol keɓe keertiiɗe
+features-index-opted-in-to-privacy-so-you = Ina daranii suturo, mbele mbaawaa wanngaade e wellitaare.
+features-index-read-our-privacy-policy = Tar dawrugol suturo amen
+# Obsolete string
+features-index-more-private = Ɓeydu suturo
+features-index-we-dont-sell-access-to-your = Min njeeyataa keɓgol keɓe enternet mon. Toɓɓere.
+features-index-get-firefox-for-privacy = Heɓ { -brand-name-firefox } ngam suturo

--- a/fi/firefox/features/index.ftl
+++ b/fi/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Suojaa yksityisyyttäsi ja selaa nopeammin { -brand-name-firefox }in ominaisuuksien ansiosta
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Sinä hallitset { -brand-name-firefox }in helppokäyttöisiä ominaisuuksia, joiden avulla suojaat yksityisyyttäsi ja parannat selailunopeutta.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox }in ominaisuudet
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Koe uuden { -brand-name-firefox }-selaimen ominaisuudet
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Lempilisäosasi ja -laajennuksesi
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Muokkaa selaintasi
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synkronoi laitteiden välillä
+# Obsolete string
+features-index-tabs-that-travel = Matkaavat välilehdet
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Paremmat kirjanmerkit
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Aiempaa tehokkaampi yksityinen selaus
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Mainosseurantaohjelmien esto
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Salasanojen hallinta
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Tasapainoinen muistinkulutus
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Selaa nopeammin
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox }in edut
+# Obsolete string
+features-index-open-source = Avointa lähdekoodia
+# Obsolete string
+features-index-were-always-transparent = Olemme aina läpinäkyviä.
+# Obsolete string
+features-index-see-what-makes-us-different = Katso, mikä tekee meistä erilaisen
+features-index-by-non-profit-mozilla = Voittoa tavoittelemattolta { -brand-name-mozilla }lta
+# Obsolete string
+features-index-protecting-the-health-of-the = Internetin terveyttä suojellen.
+features-index-read-mozillas-mission = Lue { -brand-name-mozilla }n missio
+# Obsolete string
+features-index-protect-your-rights = Suojele oikeuksiasi
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Autamme pitämään yritysten vallan kurissa.
+features-index-choose-independence = Valitse riippumaton
+# Obsolete string
+features-index-limited-data-collection = Rajoitettu tietojenkeruu
+features-index-opted-in-to-privacy-so-you = Oletusarvoisesti yksityinen, joten voit selata vapaasti.
+features-index-read-our-privacy-policy = Lue tietosuojakäytäntömme
+# Obsolete string
+features-index-more-private = Yksityisempi
+features-index-we-dont-sell-access-to-your = Verkossa olevat tietosi eivät ole myynnissä, piste.
+features-index-get-firefox-for-privacy = Hanki { -brand-name-firefox } yksityisyytesi vuoksi

--- a/fr/firefox/features/index.ftl
+++ b/fr/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protégez votre vie privée et naviguez plus rapidement grâce aux fonctionnalités { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = C’est vous qui contrôlez les options de { -brand-name-firefox } qui sont faciles à utiliser, protègent votre vie privée et accélèrent votre navigation.
+# Hero title
+features-index-firefox-features = Fonctionnalités de { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Explorez les fonctionnalités du tout nouveau { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Vos modules et extensions favoris
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Un navigateur qui s’adapte à vos désirs
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synchronisez vos appareils
+# Obsolete string
+features-index-tabs-that-travel = Faites voyager vos onglets
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = De meilleurs marque-pages
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navigation privée renforcée
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blocage des traqueurs publicitaires
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Gestionnaire de mots de passe
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Consommation mémoire équilibrée
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Naviguez plus rapidement
+# Obsolete string
+features-index-firefox-product-benefits = Les avantages de { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Open source
+# Obsolete string
+features-index-were-always-transparent = Nous sommes toujours transparents.
+# Obsolete string
+features-index-see-what-makes-us-different = Voyez en quoi nous sommes différents
+features-index-by-non-profit-mozilla = Résolument à but non lucratif
+# Obsolete string
+features-index-protecting-the-health-of-the = Nous protégeons la bonne santé d’Internet.
+features-index-read-mozillas-mission = Découvrez la mission de { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Nous protégeons vos droits
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Nous aidons à contrecarrer les plans des grandes entreprises.
+features-index-choose-independence = Choisissez l’indépendance
+# Obsolete string
+features-index-limited-data-collection = Collecte de données limitée
+features-index-opted-in-to-privacy-so-you = Votre confidentialité est assurée par défaut pour une navigation sans souci.
+features-index-read-our-privacy-policy = Consultez notre politique de confidentialité
+# Obsolete string
+features-index-more-private = Davantage de vie privée
+features-index-we-dont-sell-access-to-your = Nous ne vendons pas d’accès à vos données en ligne. Point final.
+features-index-get-firefox-for-privacy = Adoptez { -brand-name-firefox } pour la protection de votre vie privée

--- a/fy-NL/firefox/features/index.ftl
+++ b/fy-NL/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Beskermje jo privacy en surf flugger mei { -brand-name-firefox }-funksjes
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Jo hawwe de kontrôle mei { -brand-name-firefox }’ ienfâldich te brûken funksjes dy't jo privacy en surffaasjes beskermje.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox }-funskjes
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Untdek de funksjes fan de folslein nije { -brand-name-firefox }-browser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Jo favorite add-ons en útwreidingen
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Pas jo browser oan
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Syngronisearje tusken apparaten
+# Obsolete string
+features-index-tabs-that-travel = Ljepblêden dy't reizgje
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Bettere blêdwizers
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Krêftigere Priveenavigaasje
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blokkearjen fan advertinsjetrackers
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Wachtwurdenbehearder
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Balansearre ûnthâldgebrûk
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Surf flugger
+# Obsolete string
+features-index-firefox-product-benefits = Foardielen fan { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Iepen boarne
+# Obsolete string
+features-index-were-always-transparent = Wy binne altyd transparant.
+# Obsolete string
+features-index-see-what-makes-us-different = Besjoch wat ús oars makket
+features-index-by-non-profit-mozilla = Fan { -brand-name-mozilla }, in non-profitorganisaasje
+# Obsolete string
+features-index-protecting-the-health-of-the = Dy't de sûnens fan it ynternet beskermet.
+features-index-read-mozillas-mission = Lês { -brand-name-mozilla }'s misje
+# Obsolete string
+features-index-protect-your-rights = Beskermje jo rjochten
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Wy helpe saaklike foech yn 'e tange te hâlden.
+features-index-choose-independence = Kies ûnôfhinklikheid
+# Obsolete string
+features-index-limited-data-collection = Beheinde gegevenssammeling
+features-index-opted-in-to-privacy-so-you = Keazen foar privacy, sadat jo frij browse kinne.
+features-index-read-our-privacy-policy = Lês ús privacybelied
+# Obsolete string
+features-index-more-private = Mear privee
+features-index-we-dont-sell-access-to-your = Wy ferkeapje gjin tagong ta jo onlinegegevens. Punt.
+features-index-get-firefox-for-privacy = Download { -brand-name-firefox } foar privacy

--- a/ga-IE/firefox/features/index.ftl
+++ b/ga-IE/firefox/features/index.ftl
@@ -1,0 +1,54 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Cosain do phríobháideachas agus brabhsáil níos sciobtha le gnéithe { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Bain triail as gnéithe so-úsáidte in { -brand-name-firefox } chun do phríobháideachas a chosaint agus dlús a chur leis an mbrabhsálaí.
+# Hero title
+features-index-firefox-features = Gnéithe { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Na breiseáin agus na heisínteachtaí is ansa leat
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Do bhrabhsálaí a shaincheapadh
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sioncronú idir gléasanna
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Leabharmharcanna níos fearr
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Brabhsáil Phríobháideach níos cumhachtaí
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Cosc ar lorgairí
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Bainisteoir Focal Faire
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Úsáid chothromaithe chuimhne
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Brabhsáil níos sciobtha
+# Obsolete string
+features-index-open-source = Foinse oscailte
+# Obsolete string
+features-index-were-always-transparent = Trédhearcach i gcónaí.
+# Obsolete string
+features-index-see-what-makes-us-different = Féach cé chomh difriúil atáimid
+features-index-by-non-profit-mozilla = Le { -brand-name-mozilla }, eagraíocht neamhbhrabúis
+# Obsolete string
+features-index-protecting-the-health-of-the = Ag seasamh ar son shláinte an Idirlín.
+features-index-read-mozillas-mission = Léigh ár ráiteas misin
+# Obsolete string
+features-index-protect-your-rights = Seasamh ar son do cheart
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Coinnímid srian ar na mórchomhlachtaí corparáideacha.
+features-index-choose-independence = Roghnaigh an neamhspleáchas
+# Obsolete string
+features-index-limited-data-collection = Bailiú sonraí teoranta
+features-index-opted-in-to-privacy-so-you = Príobháideachas de réir réamhshocraithe — brabhsáil leat!
+features-index-read-our-privacy-policy = Léigh ár bpolasaí príobháideachais
+# Obsolete string
+features-index-more-private = Níos príobháidí
+features-index-we-dont-sell-access-to-your = Ní dhíolaimid do chuid sonraí ar líne. Lánstad.
+features-index-get-firefox-for-privacy = { -brand-name-firefox } ar son an phríobháideachais

--- a/gd/firefox/features/index.ftl
+++ b/gd/firefox/features/index.ftl
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# Hero title
+features-index-firefox-features = Gleusan { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Gnàthaich am brabhsair agad
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Comharran-lìn nas fhearr
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Brabhsadh prìobhaideach nas cumhachdaiche
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Manaidsear nam faclan-faire
+# Obsolete string
+features-index-firefox-product-benefits = Buannachdan { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Còd fosgailte
+# Obsolete string
+features-index-see-what-makes-us-different = Carson a tha sinn eadar-dhealaichte
+features-index-read-mozillas-mission = Leugh mun mhisean aig { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Dìon do chòraichean
+features-index-choose-independence = ’S fheairrde duine neo-eisimeileachd
+features-index-read-our-privacy-policy = Leugh am poileasaidh prìobhaideachd againn
+features-index-get-firefox-for-privacy = Faigh { -brand-name-firefox } airson prìobhaideachd

--- a/gl/firefox/features/index.ftl
+++ b/gl/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protexa a súa privacidade e navegue máis rápido coas características integradas no { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Vostede controla as características do { -brand-name-firefox } que son fáciles de usar, protexen a súa privacidade e aceleran a súa navegación.
+# Hero title
+features-index-firefox-features = Características do { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Descubra as características do novo navegador { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Os seus complementos e extensións favoritas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personalice o seu navegador
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincronice datos entre dispositivos
+# Obsolete string
+features-index-tabs-that-travel = Lapelas máis dinámicas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Mellores marcadores
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navegación privada máis potente
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Bloqueo de elementos de seguimento de publicidade
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Xestor de contrasinais
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Uso de memoria equilibrado
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Navegue máis rápido
+# Obsolete string
+features-index-firefox-product-benefits = As vantaxes do { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Código aberto
+# Obsolete string
+features-index-were-always-transparent = Sempre somos transparentes.
+# Obsolete string
+features-index-see-what-makes-us-different = Vexa o que nos fai diferentes
+features-index-by-non-profit-mozilla = { -brand-name-mozilla }, sen ánimo de lucro
+# Obsolete string
+features-index-protecting-the-health-of-the = Para protexer a saúde de Internet.
+features-index-read-mozillas-mission = Descubra a misión de { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Protexemos os seus dereitos
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Axudamos a controlar os poderes corporativos.
+features-index-choose-independence = Escolla a independencia
+# Obsolete string
+features-index-limited-data-collection = Recollida de datos limitada
+features-index-opted-in-to-privacy-so-you = Escolla a privacidade para navegar en liberdade.
+features-index-read-our-privacy-policy = Lea a nosa política de privacidade
+# Obsolete string
+features-index-more-private = Máis privado
+features-index-we-dont-sell-access-to-your = Mozilla non vende os seus datos persoais, punto.
+features-index-get-firefox-for-privacy = Adopte { -brand-name-firefox } para protexer a súa privacidade

--- a/gn/firefox/features/index.ftl
+++ b/gn/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Emo’ã ne ñemigua ha eikundaha pya’eve { -brand-name-firefox } rembiapo pyahu ndive
+# HTML page description
+features-index-youre-in-control-with-firefoxs = { -brand-name-firefox } rembiapo omo’ãva ne ñemigua ha kundaha pya’ekue, ndejehegui.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } rehegua
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Ejeporeka { -brand-name-firefox } kundaha pyahu jepuru rehegua
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Nde rembipuru’i ha moĩmbaha reguerohoryvéva
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Emomba’ete ne kundaha
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Mba’e’oka ñembojuehe
+# Obsolete string
+features-index-tabs-that-travel = Tendayke oku’éva
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Techaukaha iporãvéva
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Kundaha ñemigua imbaretevéva
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Ñemurã jejoko jehekaha ndive
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Ñe’ẽñemi ñangarekoha
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Mandu’arenda jepuru porã
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Eikundaha pya’eve
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } jopói
+# Obsolete string
+features-index-open-source = Ayvu ijurujáva
+# Obsolete string
+features-index-were-always-transparent = Ore reko resakã tapiaite.
+# Obsolete string
+features-index-see-what-makes-us-different = Ehechamína mba’épa oremoambuéva
+features-index-by-non-profit-mozilla = { -brand-name-mozilla } mba’e, viru’ỹre romba’apo
+# Obsolete string
+features-index-protecting-the-health-of-the = Emo’ã ñanduti reko.
+features-index-read-mozillas-mission = Emoñe’ẽ { -brand-name-mozilla } rembipota
+# Obsolete string
+features-index-protect-your-rights = Emo’ã nde derécho
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Ore pytyvõ roguereko hag̃ua atyguasu ma’ẽag̃uíme.
+features-index-choose-independence = Eiporavo jeikosã’ỹ
+# Obsolete string
+features-index-limited-data-collection = Sa’i mba’ekuaarã ñembyaty
+features-index-opted-in-to-privacy-so-you = Ñemigua poravorã eikundaha hag̃ua nde jehegui.
+features-index-read-our-privacy-policy = Emoñe’ẽ ore remiñemi purureko
+# Obsolete string
+features-index-more-private = Ñemiguave
+features-index-we-dont-sell-access-to-your = Norohepyme’ẽi nde mba’ekuaarã ñandutiguávape jeike. Kyta.
+features-index-get-firefox-for-privacy = Emboguejy { -brand-name-firefox } nde rekoñemirã

--- a/gu-IN/firefox/features/index.ftl
+++ b/gu-IN/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = તમારી ગોપનીયતાને સુરક્ષિત કરો અને { -brand-name-firefox } સુવિધાઓ સાથે ઝડપી બ્રાઉઝ કરો
+# HTML page description
+features-index-youre-in-control-with-firefoxs = તમારી ગોપનીયતા સુરક્ષિત અને { -brand-name-firefox } સુવિધાઓ સાથે ઝડપી બ્રાઉઝ કરો.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } લક્ષણો
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = તમામ નવા { -brand-name-firefox } બ્રાઉઝરની સુવિધાઓનું અન્વેષણ કરો
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = તમારા મનપસંદ ઍડ-ઑન્સ અને એક્સ્ટેન્શન્સ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = તમારા બ્રાઉઝરને ફેરફાર કરો
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = ઉપકરણો વચ્ચે સમન્વયન
+# Obsolete string
+features-index-tabs-that-travel = પ્રવાસ કરતા ટેબ્સ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = વધારે સારા બુકમાર્ક્સ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = વધુ શક્તિશાળી ખાનગી બ્રાઉઝિંગ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = જાહેરાત ટ્રેકરને અવરોધિત કરવું
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = પાસવર્ડ વ્યવસ્થાપક
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = સંતુલિત મેમરી વપરાશ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = ઝડપી બ્રાઉઝ કરો
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } ઉત્પાદન લાભો
+# Obsolete string
+features-index-open-source = ઓપન સોર્સ
+# Obsolete string
+features-index-were-always-transparent = અમે હંમેશા પારદર્શક છીએ.
+# Obsolete string
+features-index-see-what-makes-us-different = અમને અલગ બનાવે છે તે જુઓ
+features-index-by-non-profit-mozilla = બિન નફાકારક દ્વારા, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = ઇન્ટરનેટના સ્વાસ્થ્યનું રક્ષણ.
+features-index-read-mozillas-mission = { -brand-name-mozilla } નું મિશન વાંચો
+# Obsolete string
+features-index-protect-your-rights = તમારા અધિકારોનું રક્ષણ કરો
+# Obsolete string
+features-index-we-help-keep-corporate-powers = અમે કોર્પોરેટ સત્તાઓને તપાસ રાખવામાં મદદ કરીએ છીએ.
+features-index-choose-independence = સ્વતંત્ર પસંદ કરો
+# Obsolete string
+features-index-limited-data-collection = મર્યાદિત ડેટા સંગ્રહ
+features-index-opted-in-to-privacy-so-you = ગોપનીયતા માટે પસંદ કરેલ છે, જેથી તમે મુક્ત રૂપે બ્રાઉઝ કરી શકો છો.
+features-index-read-our-privacy-policy = અમારી ગોપનીયતા નીતિ વાંચો
+# Obsolete string
+features-index-more-private = વધુ ખાનગી
+features-index-we-dont-sell-access-to-your = અમે તમારા ઑનલાઇન ડેટાની ઍક્સેસ વેચતા નથી. ક્યારેક.
+features-index-get-firefox-for-privacy = ગોપનીયતા માટે { -brand-name-firefox } મેળવો

--- a/he/firefox/features/index.ftl
+++ b/he/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = ניתן להגן על הפרטיות שלך ולגלוש מהר יותר עם התכונות של { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = השליטה בידיך עם התכונות הנוחות של { -brand-name-firefox } שמגנות על הפרטיות ועל מהירות הגלישה שלך.
+# Hero title
+features-index-firefox-features = תכונות { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = סיור בתכונות של ה־{ -brand-name-firefox } המתחדש
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = התוספות וההרחבות המועדפות עליך
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = התאמת הדפדפן שלך לטעמך
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = סנכרון בין התקנים
+# Obsolete string
+features-index-tabs-that-travel = לשוניות שמטיילות
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = סימניות משופרות
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = גלישה פרטיות עצמתית יותר
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = חסימת עוקבי פרסומות
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = מנהל ססמאות
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = שימוש מאוזן בזיכרון
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = גלישה מהירה יותר
+# Obsolete string
+features-index-firefox-product-benefits = יתרונות המוצר { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = קוד פתוח
+# Obsolete string
+features-index-were-always-transparent = אנחנו תמיד שקופים.
+# Obsolete string
+features-index-see-what-makes-us-different = ראו מה הופך אותנו לשונים
+features-index-by-non-profit-mozilla = בידי הארגון ללא מטרות הרווח, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = הגנה על בריאות האינטרנט.
+features-index-read-mozillas-mission = קריאת המטרה של { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = הגנה על הזכויות שלך
+# Obsolete string
+features-index-we-help-keep-corporate-powers = אנו מסייעים לשמור על כוחות התאגידים בתחומי הבקרה.
+features-index-choose-independence = בחירה בעצמאות
+# Obsolete string
+features-index-limited-data-collection = איסוף נתונים מוגבל
+features-index-opted-in-to-privacy-so-you = עם הרשמה לפרטיות, כדי שניתן יהיה לגלוש בחופשיות.
+features-index-read-our-privacy-policy = כדאי לקרוא את מדיניות הפרטיות
+# Obsolete string
+features-index-more-private = יותר פרטיות
+features-index-we-dont-sell-access-to-your = לא נמכור את הגישה לנתונים המקוונים שלך. נקודה.
+features-index-get-firefox-for-privacy = קבלת { -brand-name-firefox } לטובת פרטיות

--- a/hi-IN/firefox/features/index.ftl
+++ b/hi-IN/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = { -brand-name-firefox } की सुविधाओं के साथ अपनी गोपनीयता को सुरक्षित रखें और तेजी से ब्राउज़ करें.
+# HTML page description
+features-index-youre-in-control-with-firefoxs = जो आपकी गोपनीयता और ब्राउज़िंग गति को सुरक्षित बनाने वाली { -brand-name-firefox } की उपयोग में सुलभ सुविधाओं के साथ, नियंत्रण आपके हाथ में हैं.
+# Hero title
+features-index-firefox-features = फ़ायरफ़ॉक्स सुविधाएँ
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = एकदम नए { -brand-name-firefox } ब्राउज़र की सुविधाओं का अन्वेषण करें
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = आपके पसंदीदा ऐड-ऑन और एक्सटेंशन
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = अपने ब्राउज़र को अनुकूलित बनाएँ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = उपकरणों के बीच सिंक करें
+# Obsolete string
+features-index-tabs-that-travel = टैब्स जो यात्रा करते हैं
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = बेहतर पुस्तचिह्न
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = अधिक शक्तिशाली निजी ब्राउज़िंग
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = विज्ञापन ट्रैकर ब्लॉकिंग
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = पासवर्ड प्रबंधक
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = मेमोरी का संतुलित उपयोग
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = अधिक तेजी से ब्राउज़ करें
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } उत्पाद लाभ
+# Obsolete string
+features-index-open-source = मुक्त स्रोत
+# Obsolete string
+features-index-were-always-transparent = हम हमेशा पारदर्शी होते हैं.
+# Obsolete string
+features-index-see-what-makes-us-different = देखें कि हमें कौन सी चीज अलग बनाती है
+features-index-by-non-profit-mozilla = गैर-लाभ द्वारा, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = इंटरनेट के स्वास्थ्य की रक्षा करना.
+features-index-read-mozillas-mission = { -brand-name-mozilla } के मिशन को पढ़ें
+# Obsolete string
+features-index-protect-your-rights = अपने अधिकारों को सुरक्षित करें
+# Obsolete string
+features-index-we-help-keep-corporate-powers = हम कॉर्पोरेट शक्तियों नियंत्रण रखने में मदद करते हैं.
+features-index-choose-independence = आज़ादी चुनें.
+# Obsolete string
+features-index-limited-data-collection = सीमित डेटा संग्रह
+features-index-opted-in-to-privacy-so-you = गोपनीयता के लिए चयन करें, ताकि आप स्वतंत्र रूप से ब्राउज़ कर सकें.
+features-index-read-our-privacy-policy = हमारी गोपनीयता नीति को पढ़ें
+# Obsolete string
+features-index-more-private = अधिक गोपनीयता
+features-index-we-dont-sell-access-to-your = हम आपके ऑनलाइन डेटा तक पहुंच को नहीं बेचते हैं. अवधि.
+features-index-get-firefox-for-privacy = गोपनीयता के लिए { -brand-name-firefox } प्राप्त करें

--- a/hr/firefox/features/index.ftl
+++ b/hr/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Zaštiti svoju privatnost i pregledaj brže s { -brand-name-firefox }om
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Ti upravljaš jednostavnim { -brand-name-firefox } funkcijama koje štite tvoju privatnost i brzinu pregledavanja.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } funkcije
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Istraži funkcije potpuno novog { -brand-name-firefox } preglednika
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Tvoji omiljeni dodaci i proširenja
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Prilagodi svoj preglednik
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sinkroniziraj uređaje
+# Obsolete string
+features-index-tabs-that-travel = Kartice koje putuju
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Bolje zabilješke
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Snažnije privatno pregledavanje
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blokiranje oglašavačkih praćenja
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Upravljač lozinki
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Uravnoteženo korištenje memorije
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Pregledavaj brže
+# Obsolete string
+features-index-firefox-product-benefits = Prednosti { -brand-name-firefox }a
+# Obsolete string
+features-index-open-source = Otvoren kod
+# Obsolete string
+features-index-were-always-transparent = Uvijek smo transparentni.
+# Obsolete string
+features-index-see-what-makes-us-different = Pogledaj što nas čini drukčijima
+features-index-by-non-profit-mozilla = Od Mozille, neprofitne organizacije
+# Obsolete string
+features-index-protecting-the-health-of-the = Štitimo zdravlje interneta.
+features-index-read-mozillas-mission = Pročitaj Mozillinu misiju
+# Obsolete string
+features-index-protect-your-rights = Zaštiti svoja prava
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Pomažemo kontrolirati moć korporacija.
+features-index-choose-independence = Odaberi neovisnost
+# Obsolete string
+features-index-limited-data-collection = Ograničeno prikupljanje podataka
+features-index-opted-in-to-privacy-so-you = Posvećen privatnosti, za slobodno pregledavanje.
+features-index-read-our-privacy-policy = Pročitaj našu politiku privatnosti
+# Obsolete string
+features-index-more-private = Više privatnosti
+features-index-we-dont-sell-access-to-your = Ne prodajemo pristup tvojim mrežnim podacima. Točka.
+features-index-get-firefox-for-privacy = Preuzmi { -brand-name-firefox } za privatnost

--- a/hsb/firefox/features/index.ftl
+++ b/hsb/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Škitajće swoju priwatnosć a přehladujće spěšnišo z funkcijemi { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Maće kontrolu nad lochko wužiwajomnymi funkcijemi { -brand-name-firefox }, kotrež wašu priwatnosć škitaja a nad spěšnosću přehladowanja.
+# Hero title
+features-index-firefox-features = Funkcije { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Wuslědźće funkcije čisće noweho wobhladowaka { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Waše najlubše přidatki a rozšěrjenja
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Přiměrće swój wobhladowak
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synchronizujće mjez gratami
+# Obsolete string
+features-index-tabs-that-travel = Rajtarki za sobuwzaće
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Lěpše zapołožki
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Mócniši priwatny modus
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blokowanje wabjenskeho slědowanja
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Zrjadowak hesłow
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Wurunane składowe wužiće
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Spěšnišo přehladować
+# Obsolete string
+features-index-firefox-product-benefits = Lěpšiny { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Wotewrjene žórło
+# Obsolete string
+features-index-were-always-transparent = Smy přeco transparentni.
+# Obsolete string
+features-index-see-what-makes-us-different = Hladajće, štož nas rozeznawa
+features-index-by-non-profit-mozilla = Wot { -brand-name-mozilla }, powšitkownosći słužaceje organizacije
+# Obsolete string
+features-index-protecting-the-health-of-the = Škita strowosć interneta.
+features-index-read-mozillas-mission = Čitajće wo misiji { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Škitajće swoje prawa
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Pomhamy mócne předewzaća pod kontrolu dźeržeć.
+features-index-choose-independence = Rozsudźće so za njewotwisnosć
+# Obsolete string
+features-index-limited-data-collection = Wobmjezowane hromadźenje datow
+features-index-opted-in-to-privacy-so-you = Po standardźe z priwatnosću, zo byšće móhł swobodnje přehladować.
+features-index-read-our-privacy-policy = Čitajće naše prawidła priwatnosće
+# Obsolete string
+features-index-more-private = Priwatniši
+features-index-we-dont-sell-access-to-your = Přistup na waše daty online njepředawamy. Dypk.
+features-index-get-firefox-for-privacy = Wjace priwatnosće dźak { -brand-name-firefox }

--- a/hu/firefox/features/index.ftl
+++ b/hu/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Védje a magánszféráját, és böngésszen gyorsan a { -brand-name-firefox } funkcióival
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Öné az irányítás a { -brand-name-firefox } könnyen használható funkcióival, amelyek védik a magánszféráját és a böngészési sebességét.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } funkciók
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Fedezze fel a teljesen megújult { -brand-name-firefox } funkcióit
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = A kedvenc kiegészítői és bővítményei
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Szabja testre a böngészőjét
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Szinkronizáljon az eszközök közt
+# Obsolete string
+features-index-tabs-that-travel = Utazó lapok
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Jobb könyvjelzők
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Még hatékonyabb privát böngészés
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Reklámkövető blokkolás
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Jelszókezelő
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Kiegyensúlyozott memóriahasználat
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Böngésszen gyorsabban
+# Obsolete string
+features-index-firefox-product-benefits = A { -brand-name-firefox } előnyei
+# Obsolete string
+features-index-open-source = Nyílt forráskód
+# Obsolete string
+features-index-were-always-transparent = Mindig átláthatóak vagyunk.
+# Obsolete string
+features-index-see-what-makes-us-different = Nézze meg mi tesz minket különbözővé
+features-index-by-non-profit-mozilla = A nonprofit Mozillától
+# Obsolete string
+features-index-protecting-the-health-of-the = Védve az internet egészségét.
+features-index-read-mozillas-mission = Olvassa el a { -brand-name-mozilla } küldetését
+# Obsolete string
+features-index-protect-your-rights = Védje a jogait
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Segítünk ellenőrzés alatt tartani a vállalatbirodalmakat.
+features-index-choose-independence = Válassza a függetlenséget
+# Obsolete string
+features-index-limited-data-collection = Korlátozott adatgyűjtés
+features-index-opted-in-to-privacy-so-you = Az adatvédelmet tiszteletben tartva, így szabadon böngészhet.
+features-index-read-our-privacy-policy = Olvassa el az adatvédelmi nyilatkozatunkat
+# Obsolete string
+features-index-more-private = Még privátabb
+features-index-we-dont-sell-access-to-your = Nem adjuk el az online adatait. Pont.
+features-index-get-firefox-for-privacy = Szerezz be a { -brand-name-firefox }ot az adatvédelem érdekében

--- a/hy-AM/firefox/features/index.ftl
+++ b/hy-AM/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Պաշտպանեք ձեր գաղտնիությունը և դիտարկեք արագ { -brand-name-firefox }-ի յուրահատկություններով
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Դուք եք կառավարում { -brand-name-firefox }-ի՝ հեշտ օգտագործվող յուրահատկութունները, որոնք պաշտպանում են ձեր գաղտնիությունը և դիտարկման արագությունը:
+# Hero title
+features-index-firefox-features = { -brand-name-firefox }-ի յուրահատկություններ
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Բացահայտեք նոր { -brand-name-firefox }-ի բոլոր նոր յուրահատկությունները
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Ձեր ընտրյալ հավելումները և ընդլայնումները
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Հարմարեցրեք ձեր դիտարկիչը
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Համաժամեցում սարքերի միջև
+# Obsolete string
+features-index-tabs-that-travel = Ներդիրներ, որոնք ճամփորդում են
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Ավելի լավ էջանիշեր
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Ավելի հզոր Գաղտնի դիտարկում
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Գովազդի հետագծման արգելափակում
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Գաղտնաբառի կառավարում
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Հիշողության հավասարակշռված օգտագործում
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Դիտարկեք արագ
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox }-ի ծրագրերի առավելությունները
+# Obsolete string
+features-index-open-source = Բաց կոդով
+# Obsolete string
+features-index-were-always-transparent = Մենք միշտ թափանցիկ ենք:
+# Obsolete string
+features-index-see-what-makes-us-different = Տեսեք, թե ինչն է մեզ դարձնում տարբերվող
+features-index-by-non-profit-mozilla = Ոչ առևտրային, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Պաշտպանում է համաանցի առողջությունը:
+features-index-read-mozillas-mission = Կարդացեք { -brand-name-mozilla }-ի առաքելությունը
+# Obsolete string
+features-index-protect-your-rights = Պաշտպանեք ձեր իրավունքները
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Մենք օգնում ենք պահել կորպորատիվ հզորությունը:
+features-index-choose-independence = Ընտրեք անկախություն
+# Obsolete string
+features-index-limited-data-collection = Սահմանափակ տվյալների հավաքում
+features-index-opted-in-to-privacy-so-you = Հիմնված գաղտնիության վրա, ուստի կարող եք ազատորեն դիտարկել:
+features-index-read-our-privacy-policy = Կարդացեք մեր գաղտնիության դրույթները
+# Obsolete string
+features-index-more-private = Առավել գաղտնի
+features-index-we-dont-sell-access-to-your = Մենք չենք վաճառում մատչումը ձեր առցանց տվյալներին: Վե՛րջ:
+features-index-get-firefox-for-privacy = Ներբեռնեք { -brand-name-firefox }-ը գաղտնիության համար

--- a/ia/firefox/features/index.ftl
+++ b/ia/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protege tu confidentialitate e naviga plus velocemente con le functionalitates de { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Tu es in controlo con le functionalitate de { -brand-name-firefox } facile a usar, que protege tu confidentialitate e le velocitates de tu navigation.
+# Hero title
+features-index-firefox-features = Characteristicas de { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Explora le characteristicas del nove navigator { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Tu componentes additive e extensiones favorite
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personalisa tu navigator
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synchronisar inter apparatos
+# Obsolete string
+features-index-tabs-that-travel = Schedas dynamic
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Melior marcapaginas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navigation anonyme plus potente
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Bloco del publicitate traciante
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Gestor de contrasignos
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Uso equilibrate del memoria
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Naviga plus rapidemente
+# Obsolete string
+features-index-firefox-product-benefits = Beneficios de { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Open source
+# Obsolete string
+features-index-were-always-transparent = Nos es sempre transparente.
+# Obsolete string
+features-index-see-what-makes-us-different = Discoperi lo que rende nos differtente
+features-index-by-non-profit-mozilla = Per { -brand-name-mozilla }, sin fines de lucro
+# Obsolete string
+features-index-protecting-the-health-of-the = Protection del salubritate de Internet.
+features-index-read-mozillas-mission = Lege le mission de { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Defende tu derectos
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Nos adjuta a tener sub controlo le grande societates.
+features-index-choose-independence = Elige le independentia
+# Obsolete string
+features-index-limited-data-collection = Collecta de datos limitate
+features-index-opted-in-to-privacy-so-you = Optate pro tu confidentialitate, assi tu pote navigar liberemente.
+features-index-read-our-privacy-policy = Lege nostre politica de confidentialitate
+# Obsolete string
+features-index-more-private = Plus private
+features-index-we-dont-sell-access-to-your = Mozilla non vende le datos personal del usatores! Puncto.
+features-index-get-firefox-for-privacy = Adopta { -brand-name-firefox } pro tu confidentialitate

--- a/id/firefox/features/index.ftl
+++ b/id/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Lindungi privasi Anda dan menjelajah lebih cepat dengan fitur { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Anda memegang kendali dengan fitur { -brand-name-firefox } yang mudah digunakan yang melindungi privasi dan kecepatan penjelajahan Anda.
+# Hero title
+features-index-firefox-features = Fitur { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Jelajahi fitur { -brand-name-firefox } terbaru
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Pengaya dan ekstensi favorit Anda
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Ubahsuai peramban Anda
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sinkronisasi antar perangkat
+# Obsolete string
+features-index-tabs-that-travel = Tab yang bepergian
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Markah lebih baik
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Penjelajahan Pribadi yang lebih hebat
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Pemblokiran pelacak iklan
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Pengelola Sandi
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Penggunaan memori yang seimbang
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Menjelajah lebih cepat
+# Obsolete string
+features-index-firefox-product-benefits = Manfaat Produk { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Sumber terbuka
+# Obsolete string
+features-index-were-always-transparent = Kami selalu transparan.
+# Obsolete string
+features-index-see-what-makes-us-different = Lihat apa yang membuat kami berbeda
+features-index-by-non-profit-mozilla = Oleh nirlaba, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Melindungi kesehatan internet.
+features-index-read-mozillas-mission = Baca misi { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Lindungi hak-hak Anda
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Kami membantu agar kekuatan korporasi tetap terpantau.
+features-index-choose-independence = Pilih independen
+# Obsolete string
+features-index-limited-data-collection = Pengumpulan data terbatas
+features-index-opted-in-to-privacy-so-you = Atur privasi, sehingga Anda dapat menjelajah dengan bebas.
+features-index-read-our-privacy-policy = Baca kebijakan privasi kami
+# Obsolete string
+features-index-more-private = Lebih pribadi
+features-index-we-dont-sell-access-to-your = Kami tidak menjual akses ke data daring Anda. Titik.
+features-index-get-firefox-for-privacy = Dapatkan { -brand-name-firefox } untuk privasi

--- a/it/firefox/features/index.ftl
+++ b/it/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Proteggi la privacy e naviga più velocemente grazie alle funzioni integrate in { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Mantieni il controllo grazie agli strumenti integrati in { -brand-name-firefox }, proteggi la tua privacy e naviga alla massima velocità
+# Hero title
+features-index-firefox-features = Caratteristiche di { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Scopri le caratteristiche di tutti i nuovi browser { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = I tuoi componenti aggiuntivi e le tue estensioni preferite
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personalizza il browser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincronizza i dati tra vari dispositivi
+# Obsolete string
+features-index-tabs-that-travel = Schede più dinamiche
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Gestione segnalibri perfezionata
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navigazione anonima ancora più completa
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blocco delle pubblicità traccianti
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Gestione password
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Il giusto equilibrio di memoria
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Naviga più velocemente
+# Obsolete string
+features-index-firefox-product-benefits = Perché usare { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Open Source
+# Obsolete string
+features-index-were-always-transparent = Massima trasparenza.
+# Obsolete string
+features-index-see-what-makes-us-different = Scopri cosa ci rende diversi
+features-index-by-non-profit-mozilla = { -brand-name-mozilla }, senza fini di lucro
+# Obsolete string
+features-index-protecting-the-health-of-the = Per proteggere la salute di Internet.
+features-index-read-mozillas-mission = Scopri la missione { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = In difesa dei diritti online
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Vigiliamo sugli abusi delle grandi società.
+features-index-choose-independence = Scelta di indipendenza
+# Obsolete string
+features-index-limited-data-collection = Raccolta dati limitata
+features-index-opted-in-to-privacy-so-you = Scegli la privacy per navigare in libertà.
+features-index-read-our-privacy-policy = Leggi l’informativa sulla privacy Mozilla
+# Obsolete string
+features-index-more-private = Più riservato
+features-index-we-dont-sell-access-to-your = Mozilla non vende i dati personali degli utenti, punto.
+features-index-get-firefox-for-privacy = Affidati a { -brand-name-firefox } per la privacy.

--- a/ja/firefox/features/index.ftl
+++ b/ja/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = { -brand-name-firefox } の豊富な機能でプライバシーを守り、より高速にブラウジング
+# HTML page description
+features-index-youre-in-control-with-firefoxs = 使いやすいプライバシー保護機能や快適なブラウジング速度を兼ね備えた { -brand-name-firefox } なら、もっと自由にインターネットを楽しめます。
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } の機能
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = まったく新しい { -brand-name-firefox } ブラウザーの機能を探索
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = お気に入りのアドオンと拡張機能
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = ブラウザーをカスタマイズ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = 端末間で同期
+# Obsolete string
+features-index-tabs-that-travel = 旅するタブ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = より便利なブックマーク
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = よりパワフルなプライベートブラウジング
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = 広告による行動追跡のブロック
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = パスワードマネージャー
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = バランスの取れたメモリー使用量
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = より高速にブラウジング
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } 製品のメリット
+# Obsolete string
+features-index-open-source = オープンソース
+# Obsolete string
+features-index-were-always-transparent = 私たちは常に透明性を保っています。
+# Obsolete string
+features-index-see-what-makes-us-different = 私たちが他とどう違うのかを見る
+features-index-by-non-profit-mozilla = 非営利法人の { -brand-name-mozilla } が提供
+# Obsolete string
+features-index-protecting-the-health-of-the = インターネットの健全性を守るために活動しています。
+features-index-read-mozillas-mission = { -brand-name-mozilla } のミッションを読む
+# Obsolete string
+features-index-protect-your-rights = あなたの権利を守る
+# Obsolete string
+features-index-we-help-keep-corporate-powers = 私たちは大企業の力を抑える手助けをしています。
+features-index-choose-independence = 独立性を選ぼう
+# Obsolete string
+features-index-limited-data-collection = 限られたデータ収集
+features-index-opted-in-to-privacy-so-you = 最初からプライバシーが考慮されているので、安心してブラウジングできます。
+features-index-read-our-privacy-policy = プライバシーポリシーを読む
+# Obsolete string
+features-index-more-private = よりプライベートに
+features-index-we-dont-sell-access-to-your = 大前提として、私たちは第三者にあなたのオンラインデータへのアクセスを売り渡したりしません。
+features-index-get-firefox-for-privacy = プライバシーのために { -brand-name-firefox } を使う

--- a/ka/firefox/features/index.ftl
+++ b/ka/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = დაიცავით თქვენი პირადი მონაცემები და იმუშავეთ სწრაფად { -brand-name-firefox }-ის საშუალებით
+# HTML page description
+features-index-youre-in-control-with-firefoxs = თქვენს უსაფრთხოებასა და სწრაფ მუშაობაზე ზრუნავს { -brand-name-firefox }-ის მარტივად გამოსაყენებელი შესაძლებლობები.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } შესაძლებლობები
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = გაეცანით, სრულიად ახალი { -brand-name-firefox }-ბრაუზერის შესაძლებლობებს
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = თქვენი რჩეული დამატებები
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = გააფორმეთ თქვენი ბრაუზერი
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = დაასინქრონეთ
+# Obsolete string
+features-index-tabs-that-travel = მოგზაური ჩანართები
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = საუკეთესო სანიშნები
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = პირადი თვალიერების მძლავრი რეჟიმი
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = სარეკლამო ელემენტების შეზღუდვა
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = პაროლების მმართველი
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = მეხსიერების ეფექტიანი გამოყენება
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = იმუშავეთ სწრაფად
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox }-ის უპირატესობები
+# Obsolete string
+features-index-open-source = ღია წყაროს მქონე
+# Obsolete string
+features-index-were-always-transparent = ჩვენ ყოველთვის გამჭვირვალედ ვმუშაობთ.
+# Obsolete string
+features-index-see-what-makes-us-different = ნახეთ, რითი ვართ განსხვავებულები
+features-index-by-non-profit-mozilla = არამომგებიანი კომპანია { -brand-name-mozilla }-სგან
+# Obsolete string
+features-index-protecting-the-health-of-the = ინტერნეტის თავისუფლების სადარაჯოზე.
+features-index-read-mozillas-mission = გაეცანით { -brand-name-mozilla }-ს მისიას
+# Obsolete string
+features-index-protect-your-rights = დაიცავით, თქვენი უფლებები
+# Obsolete string
+features-index-we-help-keep-corporate-powers = ჩვენ დაგეხმარებით, კორპორაციული ძალაუფლების შეკავებაში.
+features-index-choose-independence = აირჩიეთ დამოუკიდებლობა
+# Obsolete string
+features-index-limited-data-collection = მონაცემების აღრიცხვის შეზღუდვა
+features-index-opted-in-to-privacy-so-you = დაცვა ყოველთვის ჩართულია, ასე რომ თავისუფლად შეგიძლიათ იმუშაოთ.
+features-index-read-our-privacy-policy = გაეცანით პირადულობის დებულებას
+# Obsolete string
+features-index-more-private = მეტად პირადი
+features-index-we-dont-sell-access-to-your = ჩვენ არ ვყიდით თქვენს პირად მონაცემებს. წერტილი.
+features-index-get-firefox-for-privacy = დააყენეთ { -brand-name-firefox } პირადულობისთვის

--- a/kab/firefox/features/index.ftl
+++ b/kab/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Mmesten tabaḍnit-ik udiɣ inig s wugar n urured s tmahilin n { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = D kečč i d aqerru n yiɣewwaren n { -brand-name-firefox } fessusen i useqdec, immestanen tabaḍnit-ik, yesɣiwilen tunigin.
+# Hero title
+features-index-firefox-features = Timahilin n { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Snirem timahilin timaynutin n yiminig amaynut { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Izegrar-ik akked yisiɣzaf-ik inurifen
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Err iminig-ik d udmawan
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Mtawi gar yibenkan
+# Obsolete string
+features-index-tabs-that-travel = Accaren irezzun
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Ticraḍ ifazen
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Ugar n useǧhed n tunigin tusligt
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Asewḥel n yineḍfaṛen n udellel
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Amsefrak n wawal uffir
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Assuder n tkatut s lqis
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Inig s zreb
+# Obsolete string
+features-index-firefox-product-benefits = Tignatin n { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Aɣbalu yeldin
+# Obsolete string
+features-index-were-always-transparent = D ifrawanen yal tikelt.
+# Obsolete string
+features-index-see-what-makes-us-different = Wali acuɣer ur yelli yiwen am nekkni
+features-index-by-non-profit-mozilla = { -brand-name-mozilla }, ur tettnadi ara tadrimt
+# Obsolete string
+features-index-protecting-the-health-of-the = Ammesten n tezmert n Internet.
+features-index-read-mozillas-mission = Ɣer tuɣdaṭ n { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Mmesten izerfan-ik
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Nxeddem amek ara nerr talast i tkebbaniyin timeqqranin.
+features-index-choose-independence = Fren timunent
+# Obsolete string
+features-index-limited-data-collection = Alqaḍ n yisefka s talast
+features-index-opted-in-to-privacy-so-you = Tabaḍnit-ik tettwaḍmen s wudem amezwer i tunigin s war uguren.
+features-index-read-our-privacy-policy = Ɣer tasertit-nneɣ n tbaḍnit
+# Obsolete string
+features-index-more-private = Ugar n tbaḍnit
+features-index-we-dont-sell-access-to-your = Ur neznuzu ara anekcum ɣer yisefka-k srid. Awal ifuk.
+features-index-get-firefox-for-privacy = Sader firefox i tbaḍnit

--- a/kk/firefox/features/index.ftl
+++ b/kk/firefox/features/index.ftl
@@ -1,0 +1,56 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = { -brand-name-firefox } бай мүмкіндіктерімен жекелікті қорғап, жылдамырақ шолыңыз
+# HTML page description
+features-index-youre-in-control-with-firefoxs = { -brand-name-firefox } қолданбасының жекелігіңізді қорғап, шолуды жылдамдататын мүмкіндіктерін өзіңіз басқарасыз.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } мүмкіндіктері
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Сіздің таңдамалы қосымшалар және кеңейтулеріңіз
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Браузеріңізді баптаңыз
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Құрылғылар арасында синхрондау
+# Obsolete string
+features-index-tabs-that-travel = Саяхатшы бетбелгілер
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Жақсырақ бетбелгілер
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Мүмкіндіктері көбірек жекелік шолуы
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Жарнамалық трекерлерді блоктау
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Парольдер басқарушысы
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Жадыны тиімді қолдану
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Жылдамырақ шолу
+# Obsolete string
+features-index-open-source = Кодтары ашық
+# Obsolete string
+features-index-were-always-transparent = Біз әрқашан мөлдір түрде жұмыс жасаймыз.
+# Obsolete string
+features-index-see-what-makes-us-different = Бізді не ерекше қылатынын көріңіз
+features-index-by-non-profit-mozilla = Коммерциялық емес { -brand-name-mozilla }-дан
+# Obsolete string
+features-index-protecting-the-health-of-the = Интернеттің денсаулығын қорғау.
+features-index-read-mozillas-mission = { -brand-name-mozilla } миссиясын оқыңыз
+# Obsolete string
+features-index-protect-your-rights = Құқықтарыңызды қорғаңыз
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Біз корпорациялардың қуаттығын шектеуге көмектесеміз.
+features-index-choose-independence = Тәуелсіз болғанын таңдаңыз
+# Obsolete string
+features-index-limited-data-collection = Деректерді шектелген жинау
+features-index-opted-in-to-privacy-so-you = Жекелік іске қосылған, еркін шолуға болады.
+features-index-read-our-privacy-policy = Жекелік саясатымызды оқыңыз
+# Obsolete string
+features-index-more-private = Көбірек жекелік
+features-index-we-dont-sell-access-to-your = Біз сіздің онлайн-деректеріңізді сатпаймыз. Нүкте.
+features-index-get-firefox-for-privacy = Жекелік үшін { -brand-name-firefox } қолданбасын алу

--- a/km/firefox/features/index.ftl
+++ b/km/firefox/features/index.ftl
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = កម្មវិធី​គ្រប់គ្រង​ពាក្យ​សម្ងាត់
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = រុករក​បាន​លឿនជាង
+# Obsolete string
+features-index-open-source = កូដចំហ

--- a/kn/firefox/features/index.ftl
+++ b/kn/firefox/features/index.ftl
@@ -1,0 +1,43 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# Hero title
+features-index-firefox-features = ಫೈರ್‌ಫಾಕ್ಸಿನ ಸವಲತ್ತುಗಳು
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = ನಿಮ್ಮ ಮೆಚ್ಚಿನ ಆಡ್-ಆನ್ ಮತ್ತು ವಿಸ್ತರಣೆಗಳು
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = ನಿಮ್ಮ ಬ್ರೌಸರ್‌ಅನ್ನು ಅಗತ್ಯಾನುಗುಣಗೊಳಿಸಿ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = ಸಾಧನಗಳ ನಡುವೆ ಸಿಂಕ್ ಮಾಡಿ
+# Obsolete string
+features-index-tabs-that-travel = ಪ್ರಯಾಣಿಸುವ ಹಾಳೆಗಳು
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = ಉತ್ತಮ ಪುಟಗುರುತುಗಳು
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = ಇನ್ನೂ ಶಕ್ತಿಯುತ ಖಾಸಗಿ ವೀಕ್ಷಣೆ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = ಜಾಹಿರಾತುಗಳ ಜಾಡುಹಿಡಿಯುವಿಕೆಯನ್ನು ನಿರ್ಬಂಧಿಸುವುದು
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = ಗುಪ್ತಪದ ನಿರ್ವಾಹಕ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = ವೇಗವಾಗಿ ಜಾಲಾಡಿ
+# Obsolete string
+features-index-open-source = ಮುಕ್ತ ಆಕರ
+# Obsolete string
+features-index-were-always-transparent = ನಾವು ಎಂದಿಗೂ ಪಾರದರ್ಶಕ.
+features-index-by-non-profit-mozilla = ಲಾಭ-ರಹಿತ, ಮೊಜಿಲ್ಲಾದಿಂದ
+# Obsolete string
+features-index-protecting-the-health-of-the = ಅಂತರ್ಜಾಲದ ಆರೋಗ್ಯವನ್ನು ರಕ್ಷಿಸಲಾಗುತ್ತಿದೆ.
+features-index-read-mozillas-mission = ಮೊಜಿಲ್ಲಾದ ಜೀವಿತೋದ್ದೇಶವನ್ನು ಓದಿ
+# Obsolete string
+features-index-protect-your-rights = ನಿಮ್ಮ ಹಕ್ಕುಗಳನ್ನು ಕಾಪಾಡಿಕೊಳ್ಳಿ
+features-index-choose-independence = ಸ್ವತಂತ್ರವಾದದ್ದನ್ನು ಆಯ್ಕೆಮಾಡು
+features-index-read-our-privacy-policy = ನಮ್ಮ ಗೌಪ್ಯತಾ ನಿಯಮವನ್ನು ಓದಿರಿ
+# Obsolete string
+features-index-more-private = ಹೆಚ್ಚು ಖಾಸಗಿತನ
+features-index-we-dont-sell-access-to-your = ನಿಮ್ಮ ಅಂತರ್ಜಾಲಾಟದ ದತ್ತಾಂಶವನ್ನು ಯಾರಿಗೂ ಮಾರಿಕೊಳ್ಳುವುದಿಲ್ಲ. ಅಷ್ಟೆ.
+features-index-get-firefox-for-privacy = ಖಾಸಗಿತನಕ್ಕೆ ಫೈರ್ಫಾಕ್ಸ್ ಅನ್ನು ಪಡೆದುಕೊಳ್ಳಿ

--- a/ko/firefox/features/index.ftl
+++ b/ko/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = { -brand-name-firefox }로 개인 정보를 보호하고 더 빠르게 탐색하십시오.
+# HTML page description
+features-index-youre-in-control-with-firefoxs = 개인 정보 보호 및 브라우징 속도를 보호하는 { -brand-name-firefox }의 사용하기 쉬운 기능으로 제어 할 수 있습니다.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } 주요 기능
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = 새로운 { -brand-name-firefox } 브라우저의 기능을 둘러보기
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = 부가 기능과 확장 기능
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = 브라우저 개인화
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = 기기간 동기화
+# Obsolete string
+features-index-tabs-that-travel = 탭 공유하기
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = 북마크 기능
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = 강력한 사생활 보호 모드
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = 광고 추적기 차단
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = 암호 관리자
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = 메모리 사용 최소화
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = 빠른 탐색
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } 제품 혜택
+# Obsolete string
+features-index-open-source = 오픈 소스
+# Obsolete string
+features-index-were-always-transparent = 항상 투명합니다.
+# Obsolete string
+features-index-see-what-makes-us-different = 차별성 보기
+features-index-by-non-profit-mozilla = 비영리인 { -brand-name-mozilla } 지원
+# Obsolete string
+features-index-protecting-the-health-of-the = 인터넷의 건강함을 유지합니다.
+features-index-read-mozillas-mission = { -brand-name-mozilla } 사명 읽기
+# Obsolete string
+features-index-protect-your-rights = 권리 보호
+# Obsolete string
+features-index-we-help-keep-corporate-powers = 우리는 대기업의 힘을 항상 견제합니다.
+features-index-choose-independence = 독립성 선택
+# Obsolete string
+features-index-limited-data-collection = 제한된 데이터 수집
+features-index-opted-in-to-privacy-so-you = 개인 정보를 보호하시면, 자유롭게 브라우징할 수 있습니다.
+features-index-read-our-privacy-policy = 개인 정보 보호 정책 읽기
+# Obsolete string
+features-index-more-private = 개인화
+features-index-we-dont-sell-access-to-your = 우리는 여러분의 온라인 데이터를 팔지 않습니다. 절대로요.
+features-index-get-firefox-for-privacy = 개인 정보 보호를 위한 { -brand-name-firefox } 사용하기

--- a/lij/firefox/features/index.ftl
+++ b/lij/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protezzi a teu privacy e navega veloce graçie a-e fonçioin de { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Mantegni o contròllo graçie a-i atressi integræ in { -brand-name-firefox }, protezzi a teu privacy e navega a velocitæ mascima.
+# Hero title
+features-index-firefox-features = Carateristiche do { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Descòvri tutte e carateristiche de tutti neuvi navegatoî { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = I teu conponenti azonti e estenscioin preferie
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personalizza o navegatô
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Scincronizza dæti fra dispoxitivi
+# Obsolete string
+features-index-tabs-that-travel = Feuggi ciù asbriæ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Megio segnalibbri
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navegaçion Privâ ciù potente
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blòcco de publicitæ che te tracian
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Gestion de poule segrete
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Uzo da memöia equilibrou
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Navega ciù veloce
+# Obsolete string
+features-index-firefox-product-benefits = Benefiççi di produti { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Sorgente averto
+# Obsolete string
+features-index-were-always-transparent = Niatri semmo trasparenti.
+# Obsolete string
+features-index-see-what-makes-us-different = Amia cöse ne rende diversci
+features-index-by-non-profit-mozilla = { -brand-name-mozilla }, sensa fin de goagno
+# Obsolete string
+features-index-protecting-the-health-of-the = Pe protezze a salute de l'internet.
+features-index-read-mozillas-mission = Lezzi a miscion de { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Pe protezze i teu diritti
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Amiemo cöse fan e societæ pin de palanche.
+features-index-choose-independence = Çerni l'indipendensa
+# Obsolete string
+features-index-limited-data-collection = Acugeita dæti limitâ
+features-index-opted-in-to-privacy-so-you = Çerni a privacy pe navegâ libero.
+features-index-read-our-privacy-policy = Lezzi a nòstra informativa in sciâ privacy
+# Obsolete string
+features-index-more-private = Ciù riservou
+features-index-we-dont-sell-access-to-your = Niatri no se vendemmo l'acesso a-i teu dæti in linea, ponto.
+features-index-get-firefox-for-privacy = Piggite { -brand-name-firefox } pe-a privacy

--- a/lo/firefox/features/index.ftl
+++ b/lo/firefox/features/index.ftl
@@ -1,0 +1,60 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = ປ້ອງກັນຄວາມເປັນສ່ວນຕົວ ແລະ ເລືອກໃຊ້ບໍລິການທີ່ໄວຂອງ { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = ທ່ານເປັນຜູ້ຄວບຄຸມໄດ້ເອງດ້ວຍຄຸນລັກສະນະຂອງ { -brand-name-firefox } ທີ່ໃຊ້ງານງ່າຍ ທີ່ສາມາດປົກປ້ອງຄວາມເປັນສ່ວນຕົວ ແລະ ຄວາມໄວໃນການເປີດເວັບ.
+# Hero title
+features-index-firefox-features = ຄຸນນະສົມບັດຂອງ { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = ສຳລວດຄຸນລັກສະນະໃຫມ່ໆທັງຫມົດຂອງເວັບບຣາວເຊີ { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = ສ່ວນເສີມແລະສ່ວນຂະຫຍາຍທີ່ເຈົ້າມັກ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = ປັບແຕ່ງບຣາວເຊີຂອງທ່ານ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sync ລະຫວ່າງອຸປະກອນ
+# Obsolete string
+features-index-tabs-that-travel = ເດີນທາງໄປກັບແທັບຂອງທ່ານ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = ບຸກມາກທີ່ດີກວ່າ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = ການທ່ອງເວັບທີ່ເປັນສ່ວນຕົວຫຼາຍຂຶ້ນ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = ປ້ອງກັນການຕິດຕາມຈາກໂຄສະນາ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = ຕົວຈັດການລະຫັດຜ່ານ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = ສົມດຸ່ນການໃຊ້ງານໜ່ວຍຄວາມຈຳ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = ທ່ອງເວັບໄວຂື້ນ
+# Obsolete string
+features-index-firefox-product-benefits = ປະໂຫຍດຈາກຜະລິດຕະພັນ { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = ໂອເພັນສອດ
+# Obsolete string
+features-index-were-always-transparent = ພວກເຮົາໂປ່ງໃສຢູ່ສະເໝີ
+# Obsolete string
+features-index-see-what-makes-us-different = ເບິ່ງສິ່ງທີ່ເຮັດໃຫ້ພວກເຮົາແຕກຕ່າງ
+features-index-by-non-profit-mozilla = ໂດຍການບໍ່ສະແຫວງຫາຜົນກຳໄລ,​ { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = ການປົກປ້ອງລະບົບອິນເຕີເນັດ.
+features-index-read-mozillas-mission = ອ່ານພາລະກິດຂອງ { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = ປົກປ້ອງສິດທິຂອງທ່ານ
+# Obsolete string
+features-index-we-help-keep-corporate-powers = ພວກເຮົາຊ່ວຍເຮັດໃຫ້ອໍານາດຂອງບໍລິສັດໃນການກວດສອບ.
+features-index-choose-independence = ເລືອກຜູ້ເປັນອິດສະລະ
+# Obsolete string
+features-index-limited-data-collection = ຈຳກັດການເກັບຂໍ້ມູນ
+features-index-read-our-privacy-policy = ອ່ານນະໂຍບາຍຄວາມເປັນສ່ວນຕົວຂອງພວກເຮົາ
+# Obsolete string
+features-index-more-private = ເປັນສ່ວນຕົວກວ່າ
+features-index-we-dont-sell-access-to-your = ພວກເຮົາບໍ່ຂາຍຂໍ້ມູນອອນໄລນ໌ຂອງທ່ານ.
+features-index-get-firefox-for-privacy = ດາວໂຫລດ { -brand-name-firefox } ເພື່ອຄວາມເປັນສ່ວນຕົວ

--- a/lt/firefox/features/index.ftl
+++ b/lt/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Išsaugokite savo privatumą ir naršykite greičiau su „{ -brand-name-firefox }“
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Patogios „{ -brand-name-firefox }“ savybės, neabejotinai padėsiančios apsaugoti jūsų privatumą ir naršyti sparčiai.
+# Hero title
+features-index-firefox-features = „{ -brand-name-firefox }“ savybės
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Susipažinkite su atnaujintos „{ -brand-name-firefox }“ naršyklės savybėmis
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Mėgstamiausi priedai ir plėtiniai
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Naršyklės individualizavimas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sinchronizavimas tarp įrenginių
+# Obsolete string
+features-index-tabs-that-travel = Keliaujančios kortelės
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Geresnis adresynas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Galingesnis privatusis naršymas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Reklamų seklių blokavimas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Slaptažodžių tvarkytuvė
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Subalansuotas atminties naudojimas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Dar spartesnis naršymas
+# Obsolete string
+features-index-firefox-product-benefits = „{ -brand-name-firefox }“ naršyklės privalumai
+# Obsolete string
+features-index-open-source = Atvirojo kodo
+# Obsolete string
+features-index-were-always-transparent = Visada išliekame skaidrūs.
+# Obsolete string
+features-index-see-what-makes-us-different = Sužinokite, kuo mes kitokie
+features-index-by-non-profit-mozilla = Sukurta „Mozilloje“, nesiekiant pelno
+# Obsolete string
+features-index-protecting-the-health-of-the = Palaikome internetą sveiką.
+features-index-read-mozillas-mission = Susipažinkite su „Mozillos“ misija
+# Obsolete string
+features-index-protect-your-rights = Saugome jūsų teises
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Mes padedame suvaldyti korporacijų galias.
+features-index-choose-independence = Rinkitės laisvę
+# Obsolete string
+features-index-limited-data-collection = Ribotas duomenų rinkimas
+features-index-opted-in-to-privacy-so-you = Mes atsidavę jūsų privatumui, tad galite naršyti ramiai.
+features-index-read-our-privacy-policy = Mūsų privatumo nuostatai
+# Obsolete string
+features-index-more-private = Daugiau privatumo
+features-index-we-dont-sell-access-to-your = Mes neparduodame ir niekada neparduosime prieigos prie jūsų duomenų internete.
+features-index-get-firefox-for-privacy = „{ -brand-name-firefox }“ naudokitės privačiai

--- a/lv/firefox/features/index.ftl
+++ b/lv/firefox/features/index.ftl
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } iespējas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Pārlūkojiet ātrāk

--- a/ml/firefox/features/index.ftl
+++ b/ml/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = നിങ്ങളുടെ സ്വകാര്യത സംരക്ഷിക്കുന്നതിനോടൊപ്പം ഫയർഫോക്സ് സവിശേഷതകൾ ഉപയോഗിച്ച് വേഗത്തിൽ ബ്രൗസ് ചെയ്യൂ
+# HTML page description
+features-index-youre-in-control-with-firefoxs = നിങ്ങളുടെ സ്വകാര്യതയും ബ്രൌസിംഗ് വേഗതയും പരിരക്ഷിക്കുന്ന ഫയർഫോക്സിന്റെ ഈസി ടു യൂസ് സവിശേഷതകൾ വഴി നിങ്ങൾക്ക് നിയന്ത്രിക്കാവുന്നതാണ്.
+# Hero title
+features-index-firefox-features = ഫയര്‍ഫോക്സ് വിശേഷതകള്‍
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = പുത്തന്‍ പുതിയ ഫയര്‍ഫോക്സിലെ ഫീച്ചറുകള്‍ പരിശോധിക്കുക
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = നിങ്ങളുടെ ഇഷ്ടപ്പെട്ട ആഡോണുകളും എക്സ്റ്റെന്‍ഷനുകളും
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = ബ്രൗറിനെ ഉപഭോക്തൃവത്കരിക്കുക
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = ഉപകരണങ്ങള്‍ക്കിടയിൽ സമന്വയിപ്പിക്കുക
+# Obsolete string
+features-index-tabs-that-travel = സഞ്ചരിക്കുന്ന ടാബുകള്‍
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = മികച്ച അടയാളക്കുറിപ്പുകള്‍
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = കൂടുതല്‍ ശക്തമായ സ്വകാര്യ ബ്രൗസിംഗ്
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = പരസ്യ ട്രാക്കര്‍ തടയല്‍
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = രഹസ്യവാക്ക് കൈകാര്യം ചെയ്യുക
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = സമീകൃതമായ മെമ്മറി ഉപയോഗം
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = വേഗത്തില്‍ ബ്രൗസ് ചെയ്യുക
+# Obsolete string
+features-index-firefox-product-benefits = ഫയര്‍ഫോക്സ് ഉല്‍പന്നങ്ങളുടെ ഗുണങ്ങള്‍
+# Obsolete string
+features-index-open-source = തുറന്ന സ്ത്രോതസ്സ്
+# Obsolete string
+features-index-were-always-transparent = നമ്മള്‍ എപ്പോഴും സുതാര്യമാണ്.
+# Obsolete string
+features-index-see-what-makes-us-different = ഞങ്ങളെ വ്യത്യരാക്കുന്നത് കാണുക
+features-index-by-non-profit-mozilla = ലാഭേച്ഛയില്ലാത്ത, മോസില്ല വഴി
+# Obsolete string
+features-index-protecting-the-health-of-the = ഇന്റെര്‍നെറ്റിന്റെ ആരോഗ്യം സംരക്ഷിക്കുന്നു.
+features-index-read-mozillas-mission = മോസില്ലയുടെ ദൗത്യത്തപ്പറ്റി വായിക്കുക
+# Obsolete string
+features-index-protect-your-rights = അവകാശങ്ങള്‍ സംരക്ഷിക്കുക
+# Obsolete string
+features-index-we-help-keep-corporate-powers = ഞങ്ങള്‍ കുത്തകകളുടെ ശക്തിയെ നിയന്ത്രിക്കുന്നു.
+features-index-choose-independence = സ്വതന്ത്രമായി തിരഞ്ഞെടുക്കു
+# Obsolete string
+features-index-limited-data-collection = നിയന്ത്രിത വിവര ശേഖരണം
+features-index-opted-in-to-privacy-so-you = സ്വകാര്യതയ്ക് വേണ്ടി ചെയ്തത്, നിങ്ങള്‍ക്ക് സ്വതന്ത്രമായി ബ്രൌസ് ചെയ്യാം.
+features-index-read-our-privacy-policy = സ്വകാര്യതാനയം വായിക്കുക
+# Obsolete string
+features-index-more-private = കൂടുതല്‍ സ്വകാര്യമായ
+features-index-we-dont-sell-access-to-your = ഞങ്ങള്‍ നിങ്ങളുടെ ഓണ്‍ലെന്‍ വിവരങ്ങള്‍ വില്‍ക്കില്ല. അത്രതന്നെ.
+features-index-get-firefox-for-privacy = സ്വകാര്യതയ്ക്കായി ഫയര്‍ഫോക്സ്

--- a/mr/firefox/features/index.ftl
+++ b/mr/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = { -brand-name-firefox } वैशिष्ट्यांसह आपली गोपनीयता संरक्षित करा आणि जलद ब्राउझ करा
+# HTML page description
+features-index-youre-in-control-with-firefoxs = आपण { -brand-name-firefox } च्या वापरण्यास सोप्या वैशिष्ट्यांसह नियंत्रणात आहात, जे आपली गोपनीयता आणि ब्राउझिंग गती संरक्षित करतात.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } वैशिष्ट्ये
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = नवीन { -brand-name-firefox } ब्राऊझरची सर्व वैशिष्ट्ये एक्सप्लोर करा
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = आपले आवडते अॅड-ऑन आणि विस्तार
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = आपला ब्राउझर सानुकूलित करा
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = डिव्हाइस मध्ये Sync करा
+# Obsolete string
+features-index-tabs-that-travel = प्रवास करणारे टॅब
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = चांगल्या वाचनखुणा
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = अधिक प्रबळ खाजगी ब्राउझिंग
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = जाहिरात ट्रॅकर अवरोधित करणे
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = संकेतशब्द व्यवस्थापक
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = संतुलित मेमरी वापर
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = जलद ब्राउझ करा
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } उत्पादन फायदे
+# Obsolete string
+features-index-open-source = ओपन सोर्स
+# Obsolete string
+features-index-were-always-transparent = आम्ही नेहमी पारदर्शक आहोत.
+# Obsolete string
+features-index-see-what-makes-us-different = आम्हाला वेगळं काय बनवते ते पहा
+features-index-by-non-profit-mozilla = विना-नफा { -brand-name-mozilla } द्वारे
+# Obsolete string
+features-index-protecting-the-health-of-the = इंटरनेटच्या आरोग्याचे रक्षण करत अहोत.
+features-index-read-mozillas-mission = { -brand-name-mozilla } चे ध्येय वाचा
+# Obsolete string
+features-index-protect-your-rights = आपल्या अधिकारांचे रक्षण करा
+# Obsolete string
+features-index-we-help-keep-corporate-powers = आम्ही कॉर्पोरेट शक्तींना जरब बसवतो.
+features-index-choose-independence = स्वतंत्रता निवडा
+# Obsolete string
+features-index-limited-data-collection = मर्यादित डेटा संकलन
+features-index-opted-in-to-privacy-so-you = आपण स्वैर ब्राऊझिंग करू शकाल म्हणून गोपनीयता स्वीकारलेले.
+features-index-read-our-privacy-policy = आमचा गोपनीयता करार वाचा
+# Obsolete string
+features-index-more-private = अधिक खाजगी
+features-index-we-dont-sell-access-to-your = आम्ही तुमचा ऑनलाईन डाटा विकत नाही. विषय संपला.
+features-index-get-firefox-for-privacy = गोपनीयतेसाठी { -brand-name-firefox } मिळवा

--- a/ms/firefox/features/index.ftl
+++ b/ms/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Lindungi privasi anda dan layari dengan pantas bersama ciri-ciri { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Anda mengawal ciri { -brand-name-firefox } yang-mudah-digunakan yang melindungi privasi dan kepantasan pelayaran anda.
+# Hero title
+features-index-firefox-features = Ciri-ciri { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Teroka semua ciri pelayar { -brand-name-firefox } yang serba baru ini
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Adds-on dan ekstensi kegemaran anda
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Ubah suai pelayar anda
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sync antara peranti
+# Obsolete string
+features-index-tabs-that-travel = Tab dibawa mengembara
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Tandabuku yang lebih baik
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Pelayaran Peribadi lebih berkuasa
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Penyekatan penjejak iklan
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Pengurus Kata Laluan
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Penggunaan memori seimbang
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Layari dengan pantas
+# Obsolete string
+features-index-firefox-product-benefits = Manfaat Produk { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Sumber terbuka
+# Obsolete string
+features-index-were-always-transparent = Kami sentiasa transparen.
+# Obsolete string
+features-index-see-what-makes-us-different = Lihatlah apa yang membezakan kami
+features-index-by-non-profit-mozilla = Oleh { -brand-name-mozilla }, organisasi bukan-untung
+# Obsolete string
+features-index-protecting-the-health-of-the = Melindungi kelancaran internet.
+features-index-read-mozillas-mission = Baca misi { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Lindungi hak anda
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Kami membantu mengimbangi kuasa korporat.
+features-index-choose-independence = Pilihlah kebebasan
+# Obsolete string
+features-index-limited-data-collection = Pengumpulan data terhad
+features-index-opted-in-to-privacy-so-you = Pilihlah privasi, supaya anda boleh bebas melayar.
+features-index-read-our-privacy-policy = Baca polisi privasi kami
+# Obsolete string
+features-index-more-private = Lebih peribadi
+features-index-we-dont-sell-access-to-your = Kami tidak menjual akses ke data atas talian anda. Muktamad.
+features-index-get-firefox-for-privacy = Dapatkan { -brand-name-firefox } untuk privasi

--- a/my/firefox/features/index.ftl
+++ b/my/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = { -brand-name-firefox } ၏ စွမ်းရည်များကို အသုံးပြုပြီး မြန်ဆန်ရှာဖွေပါ၊ ကိုယ်ရေးလုံခြုံမှုကို ကာကွယ်ပါ။
+# HTML page description
+features-index-youre-in-control-with-firefoxs = သင့်ကိုယ်ရေးလုံခြုံမှုနှင့် ကြည့်ရှုရာတွင် ပိုမိုမြန်ဆန်စေမှုတို့ကို ကာကွယ်ပေးသည့် { -brand-name-firefox } ၏ အလွယ်တကူ အသုံးပြုနိုင်သော လုပ်ဆောင်ချက်များနှင့်အတူ သင့်ထံတွင် ထိန်းချုပ်မှု ရှိနေသည်။
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } လုပ်ဆောင်ချက်များ
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = အားလုံးအသစ်ဖြစ်သော { -brand-name-firefox } ဘရောင်ဇာရှိ စွမ်းဆောင်ရည်များကို ရှာဖွေအသုံးပြုကြည့်ပါ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = သင်အကြိုက်ဆုံးအက်အွန်များနှင့်တိုးချဲ့မှုများ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = သင်၏ဘရောက်ဆာကို စိတ်ကြိုက်မွမ်းမံပါ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = ကိရိယာများကို တစ်ပြေးညီ ပြုလုပ်ပါ
+# Obsolete string
+features-index-tabs-that-travel = တပ်ဗ်များနှင့်အတူ လှည့်လည်ကြည့်ရှုခြင်း
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = ပိုမိုကောင်းမွန်သော စာမှတ်စနစ်
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = ပိုမိုစွမ်းရည်မြင့် သီးသန့်အသုံးပြုခြင်း
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = ကြော်ငြာနောက်ယောင်ခံများကို တားဆီးခြင်း
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = စကားဝှက် စီမံနေရာ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = ထိန်းညှိထားသော မှတ်ဉာဏ်သုံးစွဲမှု
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = မြန်ဆန်စွာ အသုံးပြုနိုင်ခြင်း
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } ထုတ်ကုန်ဆိုင်ရာ အကျိုးကျေးဇူးများ
+# Obsolete string
+features-index-open-source = ပွင့်လင်းရင်းမြစ်
+# Obsolete string
+features-index-were-always-transparent = အမြဲတမ်း ပွင့်လင်းမြင်သာစွာ လုပ်ဆောင်သည်။
+# Obsolete string
+features-index-see-what-makes-us-different = မတူထူးခြားစေသည်များကို ကြည့်ရှုပါ
+features-index-by-non-profit-mozilla = အကျိုးအမြတ်အတွက်မဟုတ်သော { -brand-name-mozilla } မှ
+# Obsolete string
+features-index-protecting-the-health-of-the = အင်တာနက်၏ ကျန်းမာရေးကို ကာကွယ်ပါ
+features-index-read-mozillas-mission = { -brand-name-mozilla } ၏ ရည်မှန်းချက်ကို ဖတ်ရှုပါ
+# Obsolete string
+features-index-protect-your-rights = ရပိုင်ခွင့်ကို ကာကွယ်ပါ
+# Obsolete string
+features-index-we-help-keep-corporate-powers = ကျွန်ုပ်တို့သည် ကော်ပိုရိတ်များ၏ လုပ်ပိုင်ခွင့်ကို တောက်လျှောက် စောင့်ကြည့်နေသည်။
+features-index-choose-independence = လွတ်လပ်မှုကို ရွေးချယ်ပါ
+# Obsolete string
+features-index-limited-data-collection = ဒေတာကောက်ခံမှု အကန့်အသတ်ဖြင့်သာ
+features-index-opted-in-to-privacy-so-you = ကိုယ်ရေးကာကွယ်မှုကို ကြိုတင်စဉ်းစားပြုလုပ်ထားသောကြောင့် သင်သည် လွတ်လပ်စွာ လည်ပတ်ကြည့်ရှုနိုင်သည်။
+features-index-read-our-privacy-policy = ကိုယ်ရေးကာကွယ်မှုမူဝါဒကို ဖတ်ရှုပါ
+# Obsolete string
+features-index-more-private = ပိုမိုသီးခြားဖြစ်စေသည်
+features-index-we-dont-sell-access-to-your = သင့်အွန်လိုင်းအသုံးပြုမှုဒေတာများကို မရောင်းပါ။ လုံးဝပဲ။
+features-index-get-firefox-for-privacy = ကိုယ်ရေးကာကွယ်မှုအတွက် { -brand-name-firefox } ကို ရယူအသုံးပြုပါ

--- a/nb-NO/firefox/features/index.ftl
+++ b/nb-NO/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Beskytt personvernet ditt og surf raskere med funksjoner i { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Du har kontrollen med { -brand-name-firefox } sine lettvinte funksjoner som beskytter ditt privatliv og surfehastigheter.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox }-funksjoner
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Utforsk funksjonene i den helt nye { -brand-name-firefox }-nettleseren
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Dine favorittutvidelser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Tilpass nettleseren din
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synkroniser mellom enheter
+# Obsolete string
+features-index-tabs-that-travel = Faner som reiser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Bedre bokmerker
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Kraftigere privat nettlesing
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blokkering av annonsesporere
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Passordbehandling
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Balansert minnebruk
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Surf raskere
+# Obsolete string
+features-index-firefox-product-benefits = Fordeler med { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Åpen kildekode
+# Obsolete string
+features-index-were-always-transparent = Vi er alltid åpne.
+# Obsolete string
+features-index-see-what-makes-us-different = Se hva som gjør oss annerledes
+features-index-by-non-profit-mozilla = Av den ideelle organisasjonen { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Beskytt internetts helse.
+features-index-read-mozillas-mission = Les { -brand-name-mozilla } sitt oppdrag
+# Obsolete string
+features-index-protect-your-rights = Vern om rettighetene dine
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Vi hjelper til med å holde styr på de kommersielle virksomheter.
+features-index-choose-independence = Velg selvstendighet
+# Obsolete string
+features-index-limited-data-collection = Begrenset datainnsamling
+features-index-opted-in-to-privacy-so-you = Velg privatliv, slik at du kan surfe fritt.
+features-index-read-our-privacy-policy = Les vår personvernerklæring
+# Obsolete string
+features-index-more-private = Mer privat
+features-index-we-dont-sell-access-to-your = Vi selger ikke tilgang til dine data. Punktum.
+features-index-get-firefox-for-privacy = Hent { -brand-name-firefox } for personvern

--- a/nl/firefox/features/index.ftl
+++ b/nl/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Bescherm uw privacy en surf sneller met { -brand-name-firefox }-functies
+# HTML page description
+features-index-youre-in-control-with-firefoxs = U hebt de controle met { -brand-name-firefox }’ eenvoudig te gebruiken functies die uw privacy en surfsnelheden beschermen.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox }-functies
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Ontdek de functies van de volledig nieuwe { -brand-name-firefox }-browser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Uw favoriete add-ons en extensies
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Pas uw browser aan
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synchroniseer tussen apparaten
+# Obsolete string
+features-index-tabs-that-travel = Tabbladen die reizen
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Betere bladwijzers
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Krachtigere Privénavigatie
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blokkeren van advertentietrackers
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Wachtwoordenbeheerder
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Gebalanceerd geheugengebruik
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Surf sneller
+# Obsolete string
+features-index-firefox-product-benefits = Voordelen van { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Open source
+# Obsolete string
+features-index-were-always-transparent = We zijn altijd transparant.
+# Obsolete string
+features-index-see-what-makes-us-different = Bekijk wat ons anders maakt
+features-index-by-non-profit-mozilla = Van { -brand-name-mozilla }, een non-profitorganisatie
+# Obsolete string
+features-index-protecting-the-health-of-the = Die de gezondheid van het internet beschermt.
+features-index-read-mozillas-mission = Lees { -brand-name-mozilla }’s missie
+# Obsolete string
+features-index-protect-your-rights = Bescherm uw rechten
+# Obsolete string
+features-index-we-help-keep-corporate-powers = We helpen zakelijke grootmachten in bedwang te houden.
+features-index-choose-independence = Kies onafhankelijkheid
+# Obsolete string
+features-index-limited-data-collection = Beperkte gegevensverzameling
+features-index-opted-in-to-privacy-so-you = Gekozen voor privacy, zodat u vrij kunt browsen.
+features-index-read-our-privacy-policy = Lees ons privacybeleid
+# Obsolete string
+features-index-more-private = Meer privé
+features-index-we-dont-sell-access-to-your = We verkopen geen toegang tot uw onlinegegevens. Punt.
+features-index-get-firefox-for-privacy = Download { -brand-name-firefox } voor privacy

--- a/nn-NO/firefox/features/index.ftl
+++ b/nn-NO/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Beskytt personvernet ditt og surf raskare med funksjonar i { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Du har kontrollen med { -brand-name-firefox } sine lette-å-bruke funksjonar som beskyttar privatlivet ditt og surfefarta.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox }-funksjonar
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Utforsk funksjonane i den heilt nye nettlesaren { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Favorittutvidingane dine
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Tilpass nettlesaren din
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sync mellom einingar
+# Obsolete string
+features-index-tabs-that-travel = Faner som reiser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Betre bokmerke
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Kraftigare Privat nettlesing
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blokkering av annonsesporfølgjarar
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Passordhandtering
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Balansert minnebruk
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Surf raskare
+# Obsolete string
+features-index-firefox-product-benefits = Fordelar med { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Open kjeldekode
+# Obsolete string
+features-index-were-always-transparent = Vi er alltid opne.
+# Obsolete string
+features-index-see-what-makes-us-different = Sjå kva som gjer oss annleis
+features-index-by-non-profit-mozilla = Av den ideelle organisasjonen { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Vern helsa til internett.
+features-index-read-mozillas-mission = Les om oppdraget til { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Vern om rettane dine
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Vi hjelper til med å halda styr på dei kommersielle verksemdene.
+features-index-choose-independence = Vel sjølvstende
+# Obsolete string
+features-index-limited-data-collection = Avgrensa datainnsamling
+features-index-opted-in-to-privacy-so-you = Vel personvern, slik at du kan surfe fritt.
+features-index-read-our-privacy-policy = Les personvernpraksisen vår
+# Obsolete string
+features-index-more-private = Meir privat
+features-index-we-dont-sell-access-to-your = Vi sel ikkje tilgang til dine data. Punktum.
+features-index-get-firefox-for-privacy = Last ned { -brand-name-firefox } for personvern

--- a/oc/firefox/features/index.ftl
+++ b/oc/firefox/features/index.ftl
@@ -1,0 +1,57 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# Hero title
+features-index-firefox-features = Foncionalitats de { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Exploratz las foncionalitats del tot novèl { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Vòstres moduls e extensions preferits
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personalizatz vòstre navigator
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincronizatz vòstres aparelhs
+# Obsolete string
+features-index-tabs-that-travel = Fasètz viatjar vòstres onglets
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = De marcapaginas melhors
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navigacion privada melhorada
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blocatge dels traçaires publicitaris
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Gestionari de senhals
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Utilizacion de memòria equilibrada
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Navegar mai rapidament
+# Obsolete string
+features-index-firefox-product-benefits = Los avantatges de { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Open source
+# Obsolete string
+features-index-were-always-transparent = Sèm totjorn transparents.
+# Obsolete string
+features-index-see-what-makes-us-different = Vejatz çò que fa que sèm diferents
+features-index-by-non-profit-mozilla = Per { -brand-name-mozilla }, pas per l’argent
+# Obsolete string
+features-index-protecting-the-health-of-the = Protegissèm la bona santat d'internet.
+features-index-read-mozillas-mission = Legissètz la mission de { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Protegissètz vòstres dreits
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Contribuissèm a gardar las entrepresas encaladas.
+features-index-choose-independence = Causissètz l'independéncia
+# Obsolete string
+features-index-limited-data-collection = Collècta de donadas limitada
+features-index-opted-in-to-privacy-so-you = Causissètz l'opcion vida privada, e poiretz navegar en fisança.
+features-index-read-our-privacy-policy = Legissètz nòstra politica de confidencialitat
+# Obsolete string
+features-index-more-private = Mai de vida privada
+features-index-we-dont-sell-access-to-your = Vendèm pas d'accès a vòstras donadas en linha. Ponch final.
+features-index-get-firefox-for-privacy = Obtenètz { -brand-name-firefox } per mai de vida privada

--- a/pa-IN/firefox/features/index.ftl
+++ b/pa-IN/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = ਫਾਇਰਫਾਕਸ ਫੀਚਰਾਂ ਨਾਲ ਆਪਣੀ ਪਰਦੇਦਾਰੀ ਨੂੰ ਬਚਾਓ ਅਤੇ ਵੱਧ ਤੇਜ਼ੀ ਨਾਲ ਬਰਾਊਜ਼ ਕਰੋ
+# HTML page description
+features-index-youre-in-control-with-firefoxs = ਤੁਸੀਂ ਫਾਇਰਫਾਕਸ ਦੇ ਵਰਤਣ ਲਈ ਸੌਖੇ ਫੀਚਰਾਂ ਨੂੰ ਕੰਟਰੋਲ ਕਰ ਸਕਦੇ ਹੋ, ਜੋ ਕਿ ਤੁਹਾਡੀ ਪਰਦੇਦਾਰੀ ਨੂੰ ਬਚਾਉਂਦੇ ਅਤੇ ਬਰਾਊਜ਼ ਕਰਨ ਦੀ ਗਤੀ ਲਈ ਹਨ।
+# Hero title
+features-index-firefox-features = ਫਾਇਰਫਾਕਸ ਫੀਚਰ
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = ਬਿਲਕੁਲ ਨਵੇਂ ਫਾਇਰਫਾਕਸ ਬਰਾਊਜ਼ਰ ਦੇ ਸਾਰੇ ਫੀਚਰਾਂ ਬਾਰੇ ਜਾਣੋ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = ਤੁਹਾਡੇ ਮਨਪਸੰਦ ਐਡ-ਆਨ ਅਤੇ ਇਕਟੈਨਸ਼ਨ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = ਆਪਣੇ ਬਰਾਊਜ਼ਰ ਨੂੰ ਕਸਟਮਾਈਜ਼ ਕਰੋ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = ਡਿਵਾਈਸਾਂ ਵਿਚਾਲੇ ਸਿੰਕ ਕਰੋ
+# Obsolete string
+features-index-tabs-that-travel = ਟੈਬਾਂ ਜੋ ਨਾਲ ਰਹਿੰਦੀਆਂ ਨੇ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = ਬਿਹਤਰ ਬੁੱਕਮਾਰਕ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = ਹੋਰ ਮਜ਼ਬੂਤ ਪ੍ਰਾਈਵੇਟ ਬਰਾਊਜ਼ਿੰਗ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = ਇਸ਼ਤਿਹਾਰ ਟਰੈਕ ਕਰਨ ਉੱਤੇ ਪਾਬੰਦੀ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = ਪਾਸਵਰਡ ਮੈਨੇਜਰ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = ਸੰਤੁਲਿਤ ਮੈਮੋਰੀ ਦੀ ਵਰਤੋਂ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = ਵੱਧ ਤੇਜ਼ੀ ਨਾਲ ਬਰਾਊਜ਼ ਕਰੋ
+# Obsolete string
+features-index-firefox-product-benefits = ਫਾਇਰਫਾਕਸ ਉਤਪਾਦ ਫਾਇਦੇ
+# Obsolete string
+features-index-open-source = ਆਜ਼ਾਦ ਸਰੋਤ
+# Obsolete string
+features-index-were-always-transparent = ਅਸੀਂ ਹਮੇਸ਼ਾ ਪਾਰਦਰਸ਼ੀ ਹਾਂ।
+# Obsolete string
+features-index-see-what-makes-us-different = ਦੇਖੋ ਕਿ ਸਾਨੂੰ ਕਿਹੜਾ ਵੱਖਰਾ ਬਣਾਉਂਦਾ ਹੈ
+features-index-by-non-profit-mozilla = ਗ਼ੈਰ-ਮੁਨਾਫ਼ਾ, ਮੌਜ਼ੀਲਾ ਵਲੋਂ
+# Obsolete string
+features-index-protecting-the-health-of-the = ਇੰਟਰਨੈਟ ਦੀ ਸਿਹਤ ਦੀ ਸੁਰੱਖਿਆ ਕਰਨਾ।
+features-index-read-mozillas-mission = ਮੋਜ਼ੀਲਾ ਦਾ ਮਕਸਦ ਪੜ੍ਹੋ
+# Obsolete string
+features-index-protect-your-rights = ਆਪਣੇ ਅਧਿਕਾਰਾਂ ਨੂੰ ਸੁਰੱਖਿਅਤ ਕਰੋ
+# Obsolete string
+features-index-we-help-keep-corporate-powers = ਅਸੀਂ ਕਾਰਪੋਰੇਟ ਸ਼ਕਤੀਆਂ ਨੂੰ ਚੈਕ ਵਿੱਚ ਰੱਖਣ ਵਿੱਚ ਮਦਦ ਕਰਦੇ ਹਾਂ।
+features-index-choose-independence = ਅਜ਼ਾਦੀ ਚੁਣੋ
+# Obsolete string
+features-index-limited-data-collection = ਸੀਮਿਤ ਡਾਟਾ ਇਕੱਠਾ ਕਰੋ
+features-index-opted-in-to-privacy-so-you = ਪਰਦੇਦਾਰੀ ਦੀ ਚੋਣ ਕਰੋ ਤਾਂ ਜੋ ਤੁਸੀਂ ਅਜ਼ਾਦ ਰੂਪ ਨਾਲ ਬਰਾਊਜ਼ ਕਰ ਸਕੋ।
+features-index-read-our-privacy-policy = ਸਾਡੀ ਪਰਦੇਦਾਰੀ ਨੀਤੀ ਪੜ੍ਹੋ
+# Obsolete string
+features-index-more-private = ਹੋਰ ਪਰਦੇਦਾਰੀ
+features-index-we-dont-sell-access-to-your = ਅਸੀਂ ਤੁਹਾਡੇ ਆਨਲਾਈਨ ਡਾਟਾ ਲਈ ਪਹੁੰਚ ਨਹੀਂ ਵੇਚਦੇ ਹਾਂ। ਗੱਲ ਖ਼ਤਮ।
+features-index-get-firefox-for-privacy = ਪਰਦੇਦਾਰੀ ਲਈ ਫਾਇਰਫਾਕਸ ਲਵੋ

--- a/pl/firefox/features/index.ftl
+++ b/pl/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Chroń swoją prywatność i przeglądaj szybciej dzięki Firefoksowi
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Masz pełną kontrolę nad prywatnością i szybkością przeglądania dzięki łatwym w użyciu funkcjom Firefoksa.
+# Hero title
+features-index-firefox-features = Możliwości Firefoksa
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Odkryj możliwości zupełnie nowego Firefoksa
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Twoje ulubione dodatki i rozszerzenia
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Dostosuj przeglądarkę
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synchronizacja między urządzeniami
+# Obsolete string
+features-index-tabs-that-travel = Przenośne karty
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Lepsze zakładki
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Bezpieczniejszy tryb prywatny
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blokowanie śledzących reklam
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Menedżer haseł
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Zrównoważone zużycie pamięci
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Przeglądaj szybciej
+# Obsolete string
+features-index-firefox-product-benefits = Zalety Firefoksa
+# Obsolete string
+features-index-open-source = Open source
+# Obsolete string
+features-index-were-always-transparent = Zawsze stawiamy sprawy jasno.
+# Obsolete string
+features-index-see-what-makes-us-different = Zobacz, co nas wyróżnia
+features-index-by-non-profit-mozilla = { -brand-name-mozilla }, organizacja non-profit
+# Obsolete string
+features-index-protecting-the-health-of-the = Chronimy zdrowie Internetu.
+features-index-read-mozillas-mission = Zapoznaj się z misją Mozilli
+# Obsolete string
+features-index-protect-your-rights = Chroń swoje prawa
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Mamy oko na internetowe korporacje.
+features-index-choose-independence = Wybierz niezależność
+# Obsolete string
+features-index-limited-data-collection = Ograniczone zbieranie danych
+features-index-opted-in-to-privacy-so-you = Domyślnie włączona prywatność, umożliwiająca beztroskie przeglądanie.
+features-index-read-our-privacy-policy = Poznaj nasze zasady ochrony prywatności
+# Obsolete string
+features-index-more-private = Większa prywatność
+features-index-we-dont-sell-access-to-your = Nie sprzedajemy dostępu do Twoich danych w Internecie, kropka.
+features-index-get-firefox-for-privacy = Pobierz Firefoksa dla prywatności

--- a/pt-BR/firefox/features/index.ftl
+++ b/pt-BR/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Proteja sua privacidade e navegue mais rápido com as funcionalidades do { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Você está no controle com recursos fáceis de usar do { -brand-name-firefox } que protegem sua privacidade e velocidade de navegação.
+# Hero title
+features-index-firefox-features = Recursos do { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Explore os recursos do novo navegador { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Suas extensões preferidas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personalize seu navegador
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincronização entre dispositivos
+# Obsolete string
+features-index-tabs-that-travel = Abas que viajam
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Favoritos melhores
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navegação privativa mais poderosa
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Bloqueio de rastreadores
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Gerenciador de senhas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Uso de memória equilibrada
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Navegue rápido
+# Obsolete string
+features-index-firefox-product-benefits = Benefícios do { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Código aberto
+# Obsolete string
+features-index-were-always-transparent = Nós somos sempre transparentes.
+# Obsolete string
+features-index-see-what-makes-us-different = Veja o que nos torna diferente
+features-index-by-non-profit-mozilla = Pela organização sem fins lucrativos, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Protegendo a saúde da Internet.
+features-index-read-mozillas-mission = Leia a missão da { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Proteja seus direitos
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Nós ajudamos a manter os poderes corporativos sob controle.
+features-index-choose-independence = Escolha a independência
+# Obsolete string
+features-index-limited-data-collection = Coleta de dados limitada
+features-index-opted-in-to-privacy-so-you = Optamos pela privacidade, para que você possa navegar livremente.
+features-index-read-our-privacy-policy = Leia nossa política de privacidade
+# Obsolete string
+features-index-more-private = Mais privativo
+features-index-we-dont-sell-access-to-your = Nós não vendemos acesso aos seus dados on-line. Ponto final.
+features-index-get-firefox-for-privacy = Instale o { -brand-name-firefox } para ter privacidade

--- a/pt-PT/firefox/features/index.ftl
+++ b/pt-PT/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Proteja a sua privacidade e navegue mais rápido com as funcionalidades do { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Você está em controlo com as funcionalidades fáceis de utilizar do { -brand-name-firefox } que protegem a sua privacidade e velocidades de navegação.
+# Hero title
+features-index-firefox-features = Funcionalidades do { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Explore as funcionalidades do novo navegador { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Os seus extras e extensões favoritos
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personalize o seu navegador
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincronize entre dispositivos
+# Obsolete string
+features-index-tabs-that-travel = Separadores que viajam
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Melhores marcadores
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navegação privada mais poderosa
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Bloqueio de trackers de anúncios
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Gestor de palavras-passe
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Utilização de memória balanceada
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Navegue mais rápido
+# Obsolete string
+features-index-firefox-product-benefits = Benefícios do produto { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Código aberto
+# Obsolete string
+features-index-were-always-transparent = Nós somos sempre transparentes.
+# Obsolete string
+features-index-see-what-makes-us-different = Veja o que nos faz diferentes
+features-index-by-non-profit-mozilla = Pela organização sem fins lucrativos, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = A proteger a saúde da internet.
+features-index-read-mozillas-mission = Leia a missão da { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Proteja os seus direitos
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Nós ajudamos a manter os poderes corporativos em cheque.
+features-index-choose-independence = Escolha a independência
+# Obsolete string
+features-index-limited-data-collection = Recolha de dados limitada
+features-index-opted-in-to-privacy-so-you = Optado por privacidade, para que navegue livremente.
+features-index-read-our-privacy-policy = Leia a nossa política de privacidade
+# Obsolete string
+features-index-more-private = Mais privado
+features-index-we-dont-sell-access-to-your = Nós não vendemos o acesso aos seus dados online. Ponto final.
+features-index-get-firefox-for-privacy = Obtenha o { -brand-name-firefox } pela privacidade

--- a/rm/firefox/features/index.ftl
+++ b/rm/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Las funcziuns da { -brand-name-firefox } protegian tia sfera privata e ta laschan navigar anc pli spert
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Mantegna la controlla - grazia a las simplas funcziuns da { -brand-name-firefox } che protegian tia sfera privata e ta laschan navigar spert.
+# Hero title
+features-index-firefox-features = Funcziuns da { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Scuvra las funcziuns dal { -brand-name-firefox } cumplettamain nov
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Tias extensiuns e tes supplements preferids
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Persunalisescha tes navigatur
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincronisescha tes apparats
+# Obsolete string
+features-index-tabs-that-travel = Tabs che viagian
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Megliers segnapaginas
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = In modus privat rinforzà
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Bloccar reclamas che fastizeschan
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Administraziun da pleds-clav
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Utilisaziun da memoria equilibrada
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Navighescha pli spert
+# Obsolete string
+features-index-firefox-product-benefits = Ils avantatgs da { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Open source
+# Obsolete string
+features-index-were-always-transparent = Nus essan adina transparents.
+# Obsolete string
+features-index-see-what-makes-us-different = Vegnir a savair pertge che nus essan differents
+features-index-by-non-profit-mozilla = Da { -brand-name-mozilla }, in'interpresa senza finamira da profit
+# Obsolete string
+features-index-protecting-the-health-of-the = Protegia l'integritad da l'internet.
+features-index-read-mozillas-mission = Legia tut davart l'idea da { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Protegia tes dretgs
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Nus ans dustain encunter ils concerns pussants.
+features-index-choose-independence = Tscherna l'independenza
+# Obsolete string
+features-index-limited-data-collection = Paucas datas rimnadas
+features-index-opted-in-to-privacy-so-you = Tia sfera privata vegn resguardada per che ti possias navigar senza quitads.
+features-index-read-our-privacy-policy = Legia nossas directivas per la protecziun da datas
+# Obsolete string
+features-index-more-private = Pli privat
+features-index-we-dont-sell-access-to-your = Nus na vendain naginas datas dad utilisaders. Punct.
+features-index-get-firefox-for-privacy = Dapli sfera privata cun { -brand-name-firefox }

--- a/ro/firefox/features/index.ftl
+++ b/ro/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Protejează-ți confidențialitatea și navighează mai rapid cu funcționalitățile { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Tu controlezi funcționalitățile ușor de utilizat din { -brand-name-firefox }, care îți protejează intimitatea și viteza de navigare.
+# Hero title
+features-index-firefox-features = Funcționalități { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Explorează funcționalitățile unui { -brand-name-firefox } nou nouț
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Suplimentele și extensiile tale favorite
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Personalizează browserul
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sincronizează între dispozitive
+# Obsolete string
+features-index-tabs-that-travel = File care călătoresc
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Marcaje mai bune
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Navigare privată mai puternică
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blocarea elementelor de urmărire din reclame
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Manager de parole
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Folosire echilibrată a memoriei
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Navighează mai rapid
+# Obsolete string
+features-index-firefox-product-benefits = Beneficiile produselor { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Cu sursă deschisă
+# Obsolete string
+features-index-were-always-transparent = Suntem mereu transparenți.
+# Obsolete string
+features-index-see-what-makes-us-different = Vezi ce ne face diferiți
+features-index-by-non-profit-mozilla = De la o organizație nonprofit, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Protejează sănătatea internetului.
+features-index-read-mozillas-mission = Citește misiunea { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Îți protejează drepturile
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Ajutăm la ținerea sub control a puterilor corporatiste.
+features-index-choose-independence = Alege independența
+# Obsolete string
+features-index-limited-data-collection = Colectare limitată de date
+features-index-opted-in-to-privacy-so-you = Am optat pentru confidențialitatea datelor pentru ca tu să poți naviga liber.
+features-index-read-our-privacy-policy = Citește politica noastră de confidențialitate
+# Obsolete string
+features-index-more-private = Mai confidențial
+features-index-we-dont-sell-access-to-your = Noi nu vindem accesul la datele tale online. Punct.
+features-index-get-firefox-for-privacy = Instalează { -brand-name-firefox } pentru confidențialitate

--- a/ru/firefox/features/index.ftl
+++ b/ru/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Защищайте вашу приватность и сёрфите быстрее с богатыми возможностями { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Вы управляете возможностями { -brand-name-firefox }, которые защищают вашу приватность и ускоряют сёрфинг.
+# Hero title
+features-index-firefox-features = Возможности { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Узнайте о возможностях абсолютно нового { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Ваши любимые дополнения и расширения
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Настройте свой браузер
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Синхронизируйтесь между устройствами
+# Obsolete string
+features-index-tabs-that-travel = Вкладки-путешественницы
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Улучшенные закладки
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Больше мощи с приватным просмотром
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Блокировка рекламных трекеров
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Управление паролями
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Сбалансированное использование памяти
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Ускорение веб-серфинга
+# Obsolete string
+features-index-firefox-product-benefits = Преимущества использования { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Открытый исходный код
+# Obsolete string
+features-index-were-always-transparent = Мы всегда прозрачны.
+# Obsolete string
+features-index-see-what-makes-us-different = Посмотрите, что делает нас другими
+features-index-by-non-profit-mozilla = От некоммерческой { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Защита здоровья Интернета.
+features-index-read-mozillas-mission = Прочитать миссию { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Защитите свои права
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Мы помогаем сдерживать мощь корпораций.
+features-index-choose-independence = Выберите независимость
+# Obsolete string
+features-index-limited-data-collection = Ограниченный сбор данных
+features-index-opted-in-to-privacy-so-you = Приватность включена, так что вы можете сёрфить свободно.
+features-index-read-our-privacy-policy = Прочитайте нашу политику приватности
+# Obsolete string
+features-index-more-private = Больше приватности
+features-index-we-dont-sell-access-to-your = Мы не продаём ваши онлайн-данные. Точка.
+features-index-get-firefox-for-privacy = Загрузите { -brand-name-firefox } для приватности

--- a/si/firefox/features/index.ftl
+++ b/si/firefox/features/index.ftl
@@ -1,0 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } විශේෂාංග
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = ඔබේ ප්‍රියතම ඈඳුම් හා දිගුවන්
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = මෙවලම් අතර සමමුහුර්ත කරන්න
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = වඩා හොද පිටුසළකුණු
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = වඩා ප්‍රබල පෞද්ගලික ගවේෂණයන්
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = දැන්වීම් හඔායෑම අවහිර කිරීම
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = මුරපද කළමනාකරු
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = සමබර මතක භාවිතයක්
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = වේගවත්ව ගවේෂණය කරන්න
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } නිෂ්පාදනයන්හි ප්‍රතිලාභ
+# Obsolete string
+features-index-open-source = විවෘත කේත
+# Obsolete string
+features-index-were-always-transparent = අප සැමවිටම විනිවිදයි.
+# Obsolete string
+features-index-see-what-makes-us-different = අප වෙනස් වන්නේ කුමකින්දැයි බලන්න
+# Obsolete string
+features-index-protecting-the-health-of-the = අන්තර්ජාලයේ සෞඛ්‍ය ආරක්ෂා කරමින්.
+features-index-read-mozillas-mission = { -brand-name-mozilla } හි මෙහෙවර කියවන්න
+# Obsolete string
+features-index-protect-your-rights = ඔබේ අයිතීන් ආරක්ෂා කරගන්න
+features-index-choose-independence = නිදහස තෝරා ගන්න
+# Obsolete string
+features-index-limited-data-collection = සීමාසහිත දත්ත එකතු කිරීම
+features-index-read-our-privacy-policy = අපගේ පුද්ගලිකත්ව ප්‍රතිපත්තිය කියවන්න

--- a/sk/firefox/features/index.ftl
+++ b/sk/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Chráňte svoje súkromie a prehliadajte rýchlejšie s funkciami { -brand-name-firefox }u
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Vy máte pod kontrolou funkcie { -brand-name-firefox }u - či už ide o nástroje na ochranu súkromia alebo na zrýchlenie prehliadania.
+# Hero title
+features-index-firefox-features = Funkcie { -brand-name-firefox }u
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Preskúmajte funkcie nového { -brand-name-firefox }u
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Vaše obľúbené doplnky a rozšírenia
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Prispôsobte si svoj prehliadač
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synchronizácia medzi zariadeniami
+# Obsolete string
+features-index-tabs-that-travel = Karty, ktoré cestujú
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Lepšie záložky
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Silnejšie súkromné prehliadanie
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blokovanie reklám
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Správca hesiel
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Vyvážená spotreba pamäte
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Prehliadajte rýchlejšie
+# Obsolete string
+features-index-firefox-product-benefits = Výhody { -brand-name-firefox }u
+# Obsolete string
+features-index-open-source = Open source
+# Obsolete string
+features-index-were-always-transparent = Sme vždy transparentní.
+# Obsolete string
+features-index-see-what-makes-us-different = Pozrite sa, čo nás odlišuje
+features-index-by-non-profit-mozilla = Od neziskovej organizácie { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Chránime zdravie internetu.
+features-index-read-mozillas-mission = Prečítajte si o misii Mozilly
+# Obsolete string
+features-index-protect-your-rights = Chráňte svoje práva
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Pomáhame udržiavať korporácie pod kontrolou.
+features-index-choose-independence = Zvoľte nezávislosť
+# Obsolete string
+features-index-limited-data-collection = Obmedzené zbieranie údajov
+features-index-opted-in-to-privacy-so-you = Previazané so súkromím, takže môžete prehliadať slobodne.
+features-index-read-our-privacy-policy = Prečítajte si naše zásady ochrany súkromia
+# Obsolete string
+features-index-more-private = Viac súkromia
+features-index-we-dont-sell-access-to-your = Nepredávame prístup k vašim online údajom. Bodka.
+features-index-get-firefox-for-privacy = Získajte { -brand-name-firefox } kvôli súkromiu

--- a/sl/firefox/features/index.ftl
+++ b/sl/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Značilnosti { -brand-name-firefox }a – zaščitite svojo zasebnost in brskajte hitreje
+# HTML page description
+features-index-youre-in-control-with-firefoxs = { -brand-name-firefox } vam omogoča nadzor s preprostimi možnostmi za zaščito zasebnosti in za hitro brskanje.
+# Hero title
+features-index-firefox-features = Značilnosti { -brand-name-firefox }a
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Raziščite značilnosti povsem novega { -brand-name-firefox }a
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Vaši priljubljeni dodatki in razširitve
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Prilagodite svoj brskalnik
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Sinhronizirajte med napravami
+# Obsolete string
+features-index-tabs-that-travel = Zavihki, ki potujejo
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Boljši zaznamki
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Zmogljivejše zasebno brskanje
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blokiranje oglaševalskih sledilcev
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Upravitelj gesel
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Uravnotežena poraba pomnilnika
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Brskajte hitreje
+# Obsolete string
+features-index-firefox-product-benefits = Prednosti { -brand-name-firefox }a
+# Obsolete string
+features-index-open-source = Odprta koda
+# Obsolete string
+features-index-were-always-transparent = Vedno smo odkriti.
+# Obsolete string
+features-index-see-what-makes-us-different = Poglejte, kaj nas dela drugačne
+features-index-by-non-profit-mozilla = Izpod rok Mozille, neprofitne organizacije
+# Obsolete string
+features-index-protecting-the-health-of-the = Varujemo zdravje interneta.
+features-index-read-mozillas-mission = Preberite Mozillino poslanstvo
+# Obsolete string
+features-index-protect-your-rights = Zaščitite svoje pravice
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Moči korporacij pomagamo držati v šahu.
+features-index-choose-independence = Izberite neodvisnost
+# Obsolete string
+features-index-limited-data-collection = Omejeno zbiranje podatkov
+features-index-opted-in-to-privacy-so-you = Zavezani k zasebnosti, da lahko brskate svobodno.
+features-index-read-our-privacy-policy = Preberite naš pravilnik o zasebnosti
+# Obsolete string
+features-index-more-private = Več zasebnosti
+features-index-we-dont-sell-access-to-your = Ne prodajamo dostopa do vaših podatkov. Pika.
+features-index-get-firefox-for-privacy = Prenesite { -brand-name-firefox } za zasebnost

--- a/sq/firefox/features/index.ftl
+++ b/sq/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Mbroni privatësinë tuaj dhe shfletoni më me shpejtësi, me veçoritë e { -brand-name-firefox }-it
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Me veçoritë e lehta për përdorim të { -brand-name-firefox }-it që mbrojnë privatësinë tuaj dhe shpejtësinë e shfletimit, kontrollin e keni ju.
+# Hero title
+features-index-firefox-features = Veçori të { -brand-name-firefox }-it
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Eksploroni veçoritë e shfletuesit { -brand-name-firefox } fringo të ri
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Shtesat dhe zgjerimet tuaja të parapëlqyera
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Përshtateni shfletuesin tuaj
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Njëkohësoni pajisje
+# Obsolete string
+features-index-tabs-that-travel = Skeda që udhëtojnë
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Faqerojtës më të mirë
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Shfletim Privat më i fuqishëm
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Shtoni bllokim gjurmuesish
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Përgjegjës Fjalëkalimesh
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Përdorim i baraspeshuar kujtese
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Shfletoni më shpejt
+# Obsolete string
+features-index-firefox-product-benefits = Të mira të { -brand-name-firefox }-it
+# Obsolete string
+features-index-open-source = Me burim të hapët
+# Obsolete string
+features-index-were-always-transparent = Jemi gjithnjë transparentë.
+# Obsolete string
+features-index-see-what-makes-us-different = Shihni ku dallojmë nga të tjerët
+features-index-by-non-profit-mozilla = Nga jofitimprurësja, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Në mbrojtje të shëndetit të internetit.
+features-index-read-mozillas-mission = Lexoni misionin e { -brand-name-mozilla }-s
+# Obsolete string
+features-index-protect-your-rights = Mbroni të drejtat tuaja
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Ndihmojmë që të mbahet nën kontroll pushteti i korporatave.
+features-index-choose-independence = Zgjidhni pavarësinë
+# Obsolete string
+features-index-limited-data-collection = Grumbullim i kufizuar të dhënash
+features-index-opted-in-to-privacy-so-you = Me privatësinë të zgjedhur, që kështu të mund të shfletoni lirisht.
+features-index-read-our-privacy-policy = Lexoni rregullat tona të privatësisë
+# Obsolete string
+features-index-more-private = Më privat
+features-index-we-dont-sell-access-to-your = Nuk shesim hyrje te të dhënat tuaja internetore. Pikë.
+features-index-get-firefox-for-privacy = Për privatësi merrni { -brand-name-firefox }-in

--- a/sr/firefox/features/index.ftl
+++ b/sr/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Заштитите вашу приватност и сурфујте брже са { -brand-name-firefox }-ом
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Ви управљате { -brand-name-firefox } могућностима које штите вашу приватност и брзину сурфовања.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } могућности
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Истражите све могућности новог { -brand-name-firefox } прегледача
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Ваши омиљени додаци и екстензије
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Уредите ваш прегледач
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Синхронизујте уређаје
+# Obsolete string
+features-index-tabs-that-travel = Језичци који путују
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Боље забелешке
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Још боље приватно прегледање
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Блокатор реклама
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Менаџер лозинки
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Балансирано коришћење меморије
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Сурфујте брже
+# Obsolete string
+features-index-firefox-product-benefits = Погодности { -brand-name-firefox } производа
+# Obsolete string
+features-index-open-source = Отворени код
+# Obsolete string
+features-index-were-always-transparent = Увек смо транспарентни.
+# Obsolete string
+features-index-see-what-makes-us-different = Погледајте шта нас чини другачијим
+features-index-by-non-profit-mozilla = Од { -brand-name-mozilla }-е, непрофитне организације
+# Obsolete string
+features-index-protecting-the-health-of-the = Штитимо здравље интернета.
+features-index-read-mozillas-mission = Детаљније о мисији { -brand-name-mozilla }-е
+# Obsolete string
+features-index-protect-your-rights = Заштитите своја права
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Ми пратимо утицај великих корпорација.
+features-index-choose-independence = Изабери независност
+# Obsolete string
+features-index-limited-data-collection = Ограничено сакупљање података
+features-index-opted-in-to-privacy-so-you = Већа приватност, како бисте могли слободно да сурфујете интернетом.
+features-index-read-our-privacy-policy = Прочитајте нашу полису приватности
+# Obsolete string
+features-index-more-private = Више приватности
+features-index-we-dont-sell-access-to-your = Ми не тргујемо вашим интернет подацима. Тачка.
+features-index-get-firefox-for-privacy = Преузмите { -brand-name-firefox } за већу приватност

--- a/sv-SE/firefox/features/index.ftl
+++ b/sv-SE/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Skydda din integritet och surfa snabbare med funktioner i { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Du har kontroll över { -brand-name-firefox } lättanvända funktioner som skyddar din integritet och surfhastigheter.
+# Hero title
+features-index-firefox-features = Funktioner i { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Utforska funktionerna i den helt nya webbläsaren { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Dina favorittillägg
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Anpassa din webbläsare
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Synkronisera mellan enheter
+# Obsolete string
+features-index-tabs-that-travel = Flikar som följer med
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Bättre bokmärken
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Mer kraftfull privat surfning
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Blockering annonsspårare
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Lösenordshanterare
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Balanserad minnesanvändning
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Surfa snabbare
+# Obsolete string
+features-index-firefox-product-benefits = Fördelar med { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Öppen källkod
+# Obsolete string
+features-index-were-always-transparent = Vi är alltid öppna.
+# Obsolete string
+features-index-see-what-makes-us-different = Se vad som gör oss annorlunda
+features-index-by-non-profit-mozilla = Av den ideella organisationen { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Skydda Internets hälsa.
+features-index-read-mozillas-mission = Läs { -brand-name-mozilla }s uppdrag
+# Obsolete string
+features-index-protect-your-rights = Skydda dina rättigheter
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Vi hjälper till att hålla företagens makt under kontroll.
+features-index-choose-independence = Välj fritthet
+# Obsolete string
+features-index-limited-data-collection = Begränsad datainsamling
+features-index-opted-in-to-privacy-so-you = Välj integritet, så du kan surfa fritt.
+features-index-read-our-privacy-policy = Läs vår sekretesspolicy
+# Obsolete string
+features-index-more-private = Mer privat
+features-index-we-dont-sell-access-to-your = Vi säljer inte tillgång till användardata. Punkt.
+features-index-get-firefox-for-privacy = Hämta { -brand-name-firefox } för integritet

--- a/ta/firefox/features/index.ftl
+++ b/ta/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = பயர்பாக்சின் வசதிகளுடன் உங்கள் தனியுரிமையைப் பாதுகாத்து விரைவாக உலாவவும்
+# HTML page description
+features-index-youre-in-control-with-firefoxs = உங்கள் தனியுரிமை மற்றும் உலாவல் வேகத்தைப் பாதுகாக்கும் பயர்பாக்சின் எளிதில் பயன்படுத்தும் வசதிகளுடன் நீங்கள் கட்டுப்பாட்டில் உள்ளீர்கள்.
+# Hero title
+features-index-firefox-features = பயர்பாக்சு வசதிகள்
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = புத்தம் புதிய பயர்பாக்சு உலாவியின் அம்சங்களை ஆராய்க
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = உங்கள் விருப்பமான மேற்சேர்க்கைகள் மற்றும் நீட்சிகள்
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = உங்கள் உலாவியைத் தனிப்பயனாக்கவும்
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = கருவிகளிடையே ஒத்திசைக்கவும்
+# Obsolete string
+features-index-tabs-that-travel = பயணம்செய்யும் கீற்றுகள்
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = சிறப்பான புத்தகக்குறிகள்
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = அதிக வலிமைவாய்ந்த தனிப்பட்ட உலாவல்
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = விளம்பர பின்தொடரி தடுப்பு
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = கடவுச்சொல் நிர்வாகி
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = சமன்செய்யப்பட்ட நினைவகப் பயன்பாடு
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = வேகமாக உலாவவும்
+# Obsolete string
+features-index-firefox-product-benefits = பயர்பாக்சு தயாரிப்பு நன்மைகள்
+# Obsolete string
+features-index-open-source = திறந்த மூலம்
+# Obsolete string
+features-index-were-always-transparent = நாங்கள் எப்போதும் வெளிப்படையானவர்கள்.
+# Obsolete string
+features-index-see-what-makes-us-different = எங்களை வேறுபட்டவர்களாக ஆக்குவதைப் பார்க்கவும்
+features-index-by-non-profit-mozilla = இலாபநோக்கற்ற மொசில்லாவால்
+# Obsolete string
+features-index-protecting-the-health-of-the = இணையத்தின் நலத்தைப் பாதுகாக்கிறது.
+features-index-read-mozillas-mission = மொசில்லாவின் இலக்கினைப் படிக்கவும்
+# Obsolete string
+features-index-protect-your-rights = உங்கள் உரிமைகளைப் பாதுகாக்கவும்
+# Obsolete string
+features-index-we-help-keep-corporate-powers = நாங்கள் பெருநிறுவன சக்திகளை கட்டுப்பாட்டில் வைக்கிறோம்.
+features-index-choose-independence = சுதந்திரத்தைத் தேர்ந்தெடுக்கவும்
+# Obsolete string
+features-index-limited-data-collection = வரம்புடைய தரவு சேகரிப்பு
+features-index-opted-in-to-privacy-so-you = தெரிந்தெடுக்கப்பட்ட தனியுரிமை, எனவே நீங்கள் சுதந்திரமாக உலாவலாம்.
+features-index-read-our-privacy-policy = எங்கள் தனியுரிமை கொள்கையைப் படிக்கவும்
+# Obsolete string
+features-index-more-private = கூடுதல் தனிமை
+features-index-we-dont-sell-access-to-your = நாங்கள் உங்கள் இணைய தரவிற்கான அணுகலை விற்க மாட்டோம். புள்ளி.
+features-index-get-firefox-for-privacy = தனியுரிமைக்கு பயர்பாக்சைப் பெறவும்

--- a/te/firefox/features/index.ftl
+++ b/te/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = { -brand-name-firefox } విశేషాంశాలతో మీ గోప్యతను రక్షించుకోండి మరియు వెగంగా విహరించండి
+# HTML page description
+features-index-youre-in-control-with-firefoxs = మీ గోప్యతను మరియు విహారణ వేగాన్ని సంరక్షించే { -brand-name-firefox } యొక్క వాడుక సులభమైన సౌలభ్యాలతో మీ చేతుల్లో నియంత్రణాధిపత్యం.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } సౌలభ్యాలు
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = సరికొత్త { -brand-name-firefox } విహారిణిలో సౌలభ్యాలను చూడండి
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = మీకు ఇష్టమైన పొడిగింతలు
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = మీ విహరిణిని అనుకూలీకరించండి
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = పరికరాల మధ్య సమకాలీకరించండి
+# Obsolete string
+features-index-tabs-that-travel = ప్రయాణించే ట్యాబులు
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = మెరుగైన ఇష్టాంశాలు
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = ఇంకా శక్తివంతమైన వ్యక్తిగత విహరణ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = ప్రకటన ట్రాకర్ల నిరోధన
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = సంకేతపదాల నిర్వహణ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = సమన్వయమైన మెమరీ వినియోగం
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = వేగంగా విహరించండి
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } ఉత్పత్తి ప్రయోజనాలు
+# Obsolete string
+features-index-open-source = ఓపెన్ సోర్సు
+# Obsolete string
+features-index-were-always-transparent = మేము ఎల్లప్పుడూ పారదర్శకంగా ఉన్నాము.
+# Obsolete string
+features-index-see-what-makes-us-different = మమ్మల్ని భిన్నంగా తయారు చేసినది ఏమిటో చూడండి
+features-index-by-non-profit-mozilla = లాభాపేక్షలేని { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = అంతర్జాల ఆరోగ్యాన్ని రక్షిస్తుంది.
+features-index-read-mozillas-mission = { -brand-name-mozilla } యొక్క ఆశయం చదవండి
+# Obsolete string
+features-index-protect-your-rights = మీ హక్కులను రక్షించండి
+# Obsolete string
+features-index-we-help-keep-corporate-powers = కార్పోరేట్ శక్తులను నియంత్రణ చేయడానికి సహాయపడతాము.
+features-index-choose-independence = స్వతంత్రతని ఎంచుకోండి
+# Obsolete string
+features-index-limited-data-collection = పరిమితమైన డేటా సేకరణ
+features-index-opted-in-to-privacy-so-you = గోప్యతను ఎంచుకున్నారు కాబట్టి స్వేచ్ఛగా విహరించవచ్చు.
+features-index-read-our-privacy-policy = మా గోప్యతా విధానాలను చదవండి
+# Obsolete string
+features-index-more-private = మరింత గోప్యత
+features-index-we-dont-sell-access-to-your = మేము మీ ఆన్‌లైన్ డాటా ప్రాప్తిని అమ్మము. .
+features-index-get-firefox-for-privacy = గోప్యత కోసం { -brand-name-firefox }ను పొందండి

--- a/th/firefox/features/index.ftl
+++ b/th/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = ป้องกันความเป็นส่วนตัวของคุณและท่องเว็บรวดเร็วกว่าด้วยคุณลักษณะของ { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = คุณเป็นผู้ควบคุมได้เองด้วยคุณลักษณะที่ใช้งานง่ายของ { -brand-name-firefox } สำหรับปกป้องความเป็นส่วนตัวและความเร็วในการเปิดเว็บ
+# Hero title
+features-index-firefox-features = คุณลักษณะของ { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = สำรวจคุณลักษณะใหม่ทั้งหมดของเว็บเบราว์เซอร์ { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = ส่วนเสริมและส่วนขยายที่คุณชื่นชอบ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = ปรับแต่งเบราว์เซอร์ของคุณ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = ซิงค์ระหว่งอุปกรณ์
+# Obsolete string
+features-index-tabs-that-travel = เดินทางไปกับแท็บของคุณ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = ที่คั่นหน้าที่ดีกว่า
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = การท่องเว็บที่เป็นส่วนตัวมากขึ้น
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = ปิดกั้นตัวติดตามโฆษณา
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = ตัวจัดการรหัสผ่าน
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = การใช้งานหน่วยความจำอย่างสมดุล
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = เรียกดูได้เร็วขึ้น
+# Obsolete string
+features-index-firefox-product-benefits = ประโยชน์ของผลิตภัณฑ์ { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = เปิดแหล่งข้อมูล
+# Obsolete string
+features-index-were-always-transparent = เราโปร่งใสเสมอ
+# Obsolete string
+features-index-see-what-makes-us-different = ดูว่าอะไรทำให้เราแตกต่าง
+features-index-by-non-profit-mozilla = โดยองค์กรไม่แสวงผลกำไร { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = ปกป้องสุขภาพของอินเทอร์เน็ต
+features-index-read-mozillas-mission = อ่านภารกิจของ { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = ปกป้องสิทธิของคุณ
+# Obsolete string
+features-index-we-help-keep-corporate-powers = เราช่วยให้อำนาจของบรรษัทถูกตรวจสอบ
+features-index-choose-independence = เลือกผู้เป็นอิสระ
+# Obsolete string
+features-index-limited-data-collection = จำกัดการเก็บข้อมูล
+features-index-opted-in-to-privacy-so-you = เลือกความเป็นส่วนตัวได้ดั้งนั้นคุณสามารถท่องเว็บได้อย่างเสรี
+features-index-read-our-privacy-policy = อ่านนโยบายความเป็นส่วนตัวของเรา
+# Obsolete string
+features-index-more-private = เป็นส่วนตัวมากขึ้น
+features-index-we-dont-sell-access-to-your = เราไม่ขายการเข้าถึงข้อมูลออนไลน์ของคุณ
+features-index-get-firefox-for-privacy = รับ { -brand-name-firefox } เพื่อความเป็นส่วนตัว

--- a/tl/firefox/features/index.ftl
+++ b/tl/firefox/features/index.ftl
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } features
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = i-Customize ang iyong browser
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Password Manager
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Balanse na paggamit ng memorya
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Mag-browse nang mas mabilis
+# Obsolete string
+features-index-open-source = Open source
+features-index-read-mozillas-mission = Basahin ang misyon ng { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Protektahan ang iyong mga karapatan
+# Obsolete string
+features-index-more-private = Mas pribado

--- a/tr/firefox/features/index.ftl
+++ b/tr/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = { -brand-name-firefox } özellikleriyle gizliliğini koru, internette daha hızlı dolaş
+# HTML page description
+features-index-youre-in-control-with-firefoxs = { -brand-name-firefox }’un gizliliğini koruyan ve gezinti hızını artıran, kullanımı kolay özellikleriyle kontrol hep sende.
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } özellikleri
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Yepyeni { -brand-name-firefox } tarayıcısının özelliklerini keşfet
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = En sevdiğin eklentiler ve uzantılar
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Tarayıcını özelleştir
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Farklı cihazları eşitle
+# Obsolete string
+features-index-tabs-that-travel = Gezgin sekmeler
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Daha iyi yer imleri
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Daha güçlü Gizli Gezinti
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Reklam takipçilerini engelle
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Parola Yöneticisi
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Dengeli bellek tüketimi
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Daha hızlı dolaş
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox }’un faydaları
+# Obsolete string
+features-index-open-source = Açık kaynaklı
+# Obsolete string
+features-index-were-always-transparent = Hep şeffafız.
+# Obsolete string
+features-index-see-what-makes-us-different = Bizi farklı yapan şeyleri gör
+features-index-by-non-profit-mozilla = Kâr amacı gütmeyen { -brand-name-mozilla }’dan
+# Obsolete string
+features-index-protecting-the-health-of-the = İnternetin sağlığını koruyoruz.
+features-index-read-mozillas-mission = { -brand-name-mozilla } misyonunu oku
+# Obsolete string
+features-index-protect-your-rights = Haklarını koruyoruz
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Kurumsal güçleri kontrol altında tutuyoruz.
+features-index-choose-independence = Bağımsızlığı seç
+# Obsolete string
+features-index-limited-data-collection = Kısıtlı veri toplama
+features-index-opted-in-to-privacy-so-you = Özgürce dolaş diye sana sormadan veri toplamıyoruz.
+features-index-read-our-privacy-policy = Gizlilik ilkelerimizi oku
+# Obsolete string
+features-index-more-private = Daha gizli
+features-index-we-dont-sell-access-to-your = Bize teslim ettiğin verileri asla satmıyoruz. Nokta.
+features-index-get-firefox-for-privacy = Gizlilik için { -brand-name-firefox }’u indir

--- a/trs/firefox/features/index.ftl
+++ b/trs/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Dugumîn sa gā huì gachēt nī gachē nu hìo doj ngà nej sa nikāj { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Ma’ânt ni’in dàj gārasunt si’iaj { -brand-name-firefox } nej sa dugumîn sò’ nī sa nagi’iaj hìo da’ gachēnunt.
+# Hero title
+features-index-firefox-features = Sa ga’ue gi’iaj { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Natsïj ni'iajt daj hua nej sa nikaj { -brand-name-firefox } nakàa 'naj
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Nej complemento ngà nej extensión garan’ ruhuât doj
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Nagi’iaj dàj garan’ ruhuât si navegadort
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Nagi’iaj nuguan’àn nej sa màan riña nej aga’ nikājt
+# Obsolete string
+features-index-tabs-that-travel = Nej rakïj ñanj a’ue aché
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Nej marcador huā hue’ê doj
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Gache nu huì nìko doj
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Sa narán riña nej anuncio naga’nāj a
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Sa dugumîn nej da’nga’ huìi
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Hue’ê gārasunt memoria
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Gachē nu hìo doj
+# Obsolete string
+features-index-firefox-product-benefits = Sa rugûñu'unj nej sa nikaj { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Huā nî’nïnj fuente
+# Obsolete string
+features-index-were-always-transparent = Yitïnj nadigân ñûnj sa ‘iaj ñûnj.
+# Obsolete string
+features-index-see-what-makes-us-different = Ni’iāj ahuin si ‘iaj da’ ninïn hua ñûnj
+features-index-by-non-profit-mozilla = Sê guendâ gi’iaj yi’ì ñûnj, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Dugumî da’ gā sà’ internet.
+features-index-read-mozillas-mission = Gahiā ahuin si huin hiūj ruhuâ { -brand-name-mozilla } gùchij
+# Obsolete string
+features-index-protect-your-rights = Dugumîn nej sa tna’uēj rayi’ît
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Rugûñu’ūnj ñûnj da’ nagà’ sa a’nïn’ nej empresa.
+features-index-choose-independence = Gida’a independencia
+# Obsolete string
+features-index-limited-data-collection = Dodò’ nahuin chre’ nej dâto
+features-index-opted-in-to-privacy-so-you = Sa huìi huin chrēj tna’uēj ñûnj, da’ gachē nunt dàj garan’ ruhuât.
+features-index-read-our-privacy-policy = Gahiā chrēj nikò’ ñûnj guendâ sa huìi
+# Obsolete string
+features-index-more-private = Gā huì doj
+features-index-we-dont-sell-access-to-your = Nitāj si dû’uej ñûnj da’ gatū nej si ni’iāj nej si sa ‘iát riña línea. Diû.
+features-index-get-firefox-for-privacy = Girì’ sa huì nikāj { -brand-name-firefox }

--- a/uk/firefox/features/index.ftl
+++ b/uk/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Захистіть свою приватність і працюйте швидше завдяки можливостям { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Ви керуєте можливостями { -brand-name-firefox }, які захищають вашу приватність і прискорюють роботу.
+# Hero title
+features-index-firefox-features = Можливості { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Дізнайтеся про можливості повністю нового браузера { -brand-name-firefox }
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Валі улюблені додатки й розширення
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Налаштуйте свій браузер
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Синхронізація між пристроями
+# Obsolete string
+features-index-tabs-that-travel = Вкладки-мандрівниці
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Покращені закладки
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Потужніший приватний перегляд
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Блокування рекламного стеження
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Керування паролями
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Збалансоване використання пам'яті
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Швидша робота
+# Obsolete string
+features-index-firefox-product-benefits = Переваги використання { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Відкритий програмний код
+# Obsolete string
+features-index-were-always-transparent = Ми завжди прозорі.
+# Obsolete string
+features-index-see-what-makes-us-different = Дізнайтеся, що робить нас іншими
+features-index-by-non-profit-mozilla = Від некомерційної { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Захист здоров'я Інтернету.
+features-index-read-mozillas-mission = Прочитати місію { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Захистіть свої права
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Ми допомагаємо стримувати міць корпорацій.
+features-index-choose-independence = Оберіть незалежність
+# Obsolete string
+features-index-limited-data-collection = Обмежений збір даних
+features-index-opted-in-to-privacy-so-you = Приватність увімкнена, отже ви можете вільно користуватися.
+features-index-read-our-privacy-policy = Прочитайте нашу політику приватності
+# Obsolete string
+features-index-more-private = Більше приватності
+features-index-we-dont-sell-access-to-your = Ми не продаємо доступ до ваших мережевих даних. Крапка.
+features-index-get-firefox-for-privacy = Завантажте { -brand-name-firefox } для приватності

--- a/ur/firefox/features/index.ftl
+++ b/ur/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = اپنی رازداری کی حفاظت کریں اور { -brand-name-firefox } کی خصوصیات کے ساتھ تیز برائوز کریں
+# HTML page description
+features-index-youre-in-control-with-firefoxs = آپ { -brand-name-firefox } کے آسان استعمال کی خصوصیات کے کنٹرول میں ہیں جو آپ کی رازداری اور براؤزنگ کی رفتار کی حفاظت کرتے ہیں۔
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } کی خصوصیات
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = { -brand-name-firefox } برائوزر کے تمام نئے فیچر دریافت کریں
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = آپ کے پسندیدہ اضافہ جات اور توسیعات
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = اپنے براؤزر کی تخصیص کریں
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = آلات کے درمیان ہمہ وقت سازی
+# Obsolete string
+features-index-tabs-that-travel = ٹیبز جو صفر کری٘ں
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = بہتر نشانیاں
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = مزید طاقتور نجی برائوزنگ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = اشتھاراتی ٹریکر کو روکنا
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = پاس ورڈ مینیجر
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = متوازن میموری کا استعمال
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = تیزی سے برائوز کریں
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } پروڈکٹ کے فوائد
+# Obsolete string
+features-index-open-source = اوپن سورس
+# Obsolete string
+features-index-were-always-transparent = ہم ہمیشہ شفاف ہیں۔
+# Obsolete string
+features-index-see-what-makes-us-different = دیکھیں ہمیں کیا مختلف بناتا ہے
+features-index-by-non-profit-mozilla = غیر منافع بخش کی جانب سے، { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = انٹرنیٹ کی صحت کی حفاظت۔
+features-index-read-mozillas-mission = { -brand-name-mozilla } کا منشور پڑھیں
+# Obsolete string
+features-index-protect-your-rights = اپنے حقوق کی حفاظت کریں
+# Obsolete string
+features-index-we-help-keep-corporate-powers = ہم کارپوریٹ طاقت پر نزر رکھنے میں مدد کرتے ہیں۔
+features-index-choose-independence = آزادی چنیں
+# Obsolete string
+features-index-limited-data-collection = محدود کوائف جمع کرنا
+features-index-opted-in-to-privacy-so-you = رازداری موڈ میں انتخاب کیا ہے، تاکہ آپ آزادانہ طور پر براؤز کرسکیں۔
+features-index-read-our-privacy-policy = ہماری کی رازداری پالیسی پڑھیں
+# Obsolete string
+features-index-more-private = مزید رازدار
+features-index-we-dont-sell-access-to-your = ہم آپ کے آن لائن ڈیٹا تک رسائی فروخت نہیں کرتے ہیں۔
+features-index-get-firefox-for-privacy = رازداری کے لیئے { -brand-name-firefox } حاصل کریں

--- a/vi/firefox/features/index.ftl
+++ b/vi/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = Bảo vệ quyền riêng tư và duyệt web nhanh hơn với các tính năng của { -brand-name-firefox }
+# HTML page description
+features-index-youre-in-control-with-firefoxs = Bạn có thể quản lý những tính năng của { -brand-name-firefox } dễ dàng để bảo mật thông tin của bạn và tăng tốc độ duyệt web.
+# Hero title
+features-index-firefox-features = Các tính năng của { -brand-name-firefox }
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = Khám phá toàn bộ tính năng của trình duyệt { -brand-name-firefox } mới
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = Những tiện ích mở rộng mà bạn yêu thích
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Tùy biến trình duyệt của bạn
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = Đồng bộ giữa các thiết bị
+# Obsolete string
+features-index-tabs-that-travel = Các thẻ có thể được gửi đi
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = Đánh dấu trang tốt hơn
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = Duyệt web riêng tư mạnh mẽ hơn
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = Chặn trình theo dõi quảng cáo
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = Quản lý mật khẩu
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = Cân bằng việc sử dụng bộ nhớ
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = Duyệt web nhanh hơn
+# Obsolete string
+features-index-firefox-product-benefits = Lợi ích sản phẩm { -brand-name-firefox }
+# Obsolete string
+features-index-open-source = Mã nguồn mở
+# Obsolete string
+features-index-were-always-transparent = Chúng tôi luôn luôn rõ ràng, chân thật.
+# Obsolete string
+features-index-see-what-makes-us-different = Tìm hiểu điều khiến chúng tôi khác biệt
+features-index-by-non-profit-mozilla = Bởi tổ chức phi lợi nhuận, { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = Bảo vệ sự tốt đẹp của internet.
+features-index-read-mozillas-mission = Đọc về sứ mệnh của { -brand-name-mozilla }
+# Obsolete string
+features-index-protect-your-rights = Bảo vệ quyền lợi chính đáng của bạn
+# Obsolete string
+features-index-we-help-keep-corporate-powers = Chúng tôi giữ sức mạnh của sự đoàn kết.
+features-index-choose-independence = Lựa chọn sự độc lập
+# Obsolete string
+features-index-limited-data-collection = Giới hạn việc thu thập dữ liệu
+features-index-opted-in-to-privacy-so-you = Được tạo ra để bảo mật thông tin của bạn, nên bạn có thể tự do duyệt web.
+features-index-read-our-privacy-policy = Đọc chính sách bảo mật của chúng tôi
+# Obsolete string
+features-index-more-private = Riêng tư hơn
+features-index-we-dont-sell-access-to-your = Chúng tôi không bán quyền truy cập dữ liệu trực tuyến của bạn. Chắc chắn.
+features-index-get-firefox-for-privacy = Tải { -brand-name-firefox } để bảo mật hơn

--- a/zam/firefox/features/index.ftl
+++ b/zam/firefox/features/index.ftl
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } Beta
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = Tùs kùe wìɁ-nêd
+# Obsolete string
+features-index-open-source = Yìb nó mb-šàlɁ

--- a/zh-CN/firefox/features/index.ftl
+++ b/zh-CN/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = 用 { -brand-name-firefox } 功能保护您的隐私，更畅快地浏览
+# HTML page description
+features-index-youre-in-control-with-firefoxs = 您可以使用 { -brand-name-firefox } 的功能来帮助保护您的隐私和浏览速度。
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } 特色
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = 探索全新 { -brand-name-firefox } 浏览器的众多特点
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = 您最喜爱的附加组件和扩展
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = 定制您的浏览器
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = 设备之间同步
+# Obsolete string
+features-index-tabs-that-travel = 让标签页飞一会
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = 更好的书签
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = 更强大的隐私浏览模式
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = 屏蔽跟踪器
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = 密码管理器
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = 平衡的内存占用
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = 浏览更快
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } 产品优势
+# Obsolete string
+features-index-open-source = 开源
+# Obsolete string
+features-index-were-always-transparent = 我们始终透明。
+# Obsolete string
+features-index-see-what-makes-us-different = 了解我们因何不同
+features-index-by-non-profit-mozilla = 非营利的 { -brand-name-mozilla }
+# Obsolete string
+features-index-protecting-the-health-of-the = 保护互联网的健康发展。
+features-index-read-mozillas-mission = 查看 { -brand-name-mozilla } 的使命
+# Obsolete string
+features-index-protect-your-rights = 保护您的权利
+# Obsolete string
+features-index-we-help-keep-corporate-powers = 我们帮助您监督企业权力，保障用户利益。
+features-index-choose-independence = 独立自主
+# Obsolete string
+features-index-limited-data-collection = 有限的数据收集
+features-index-opted-in-to-privacy-so-you = 如有忧虑，您可随时、随意取消它们。
+features-index-read-our-privacy-policy = 阅读我们的隐私政策
+# Obsolete string
+features-index-more-private = 更多隐私
+features-index-we-dont-sell-access-to-your = 我们永远不会贩卖您的上网数据。
+features-index-get-firefox-for-privacy = 捍卫隐私权，下载 { -brand-name-firefox }

--- a/zh-TW/firefox/features/index.ftl
+++ b/zh-TW/firefox/features/index.ftl
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+### URL: https://www-dev.allizom.org/firefox/features/
+
+# HTML page title
+features-index-protect-your-privacy-and-browse = 使用 { -brand-name-firefox } 的功能，保護隱私，也更快上網
+# HTML page description
+features-index-youre-in-control-with-firefoxs = 您可自行控制 { -brand-name-firefox } 能夠幫助您保護隱私，又能快速瀏覽網頁的各種易用功能。
+# Hero title
+features-index-firefox-features = { -brand-name-firefox } 功能
+# Hero description
+# Obsolete string
+features-index-explore-the-features-of-the = 探索全新 { -brand-name-firefox } 網頁瀏覽器的各種功能
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-your-favorite-add-ons-and = 您最愛的附加元件與擴充套件
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-customize-your-browser = 自訂瀏覽器
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-sync-between-devices = 在不同裝置間同步
+# Obsolete string
+features-index-tabs-that-travel = 分頁跟著一起走
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-better-bookmarks = 更好的書籤
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-more-powerful-private-browsing = 威力更強大的隱私保護功能
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-ad-tracker-blocking = 封鎖廣告追蹤器
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-password-manager = 密碼管理員
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-balanced-memory-usage = 平衡記憶體使用情況
+# Obsolete string, replaced in firefox/features/shared.ftl
+features-index-browse-faster = 上網更快
+# Obsolete string
+features-index-firefox-product-benefits = { -brand-name-firefox } 產品優勢
+# Obsolete string
+features-index-open-source = 開放原始碼
+# Obsolete string
+features-index-were-always-transparent = 我們永遠透明開放。
+# Obsolete string
+features-index-see-what-makes-us-different = 看看是什麼東西讓我們與眾不同
+features-index-by-non-profit-mozilla = 由非營利組織 { -brand-name-mozilla } 打造
+# Obsolete string
+features-index-protecting-the-health-of-the = 保護網路的生態。
+features-index-read-mozillas-mission = 了解 { -brand-name-mozilla } 的使命
+# Obsolete string
+features-index-protect-your-rights = 保護您的權利
+# Obsolete string
+features-index-we-help-keep-corporate-powers = 我們幫助您看好企業，不讓它們侵害個人權利。
+features-index-choose-independence = 獨立的選擇
+# Obsolete string
+features-index-limited-data-collection = 受限的資料收集。
+features-index-opted-in-to-privacy-so-you = 主動保護隱私，讓您可自由上網。
+features-index-read-our-privacy-policy = 閱讀我們的隱私權保護政策
+# Obsolete string
+features-index-more-private = 更加隱私
+features-index-we-dont-sell-access-to-your = 我們不會販賣您的上網資料，沒有例外。
+features-index-get-firefox-for-privacy = 為了隱私權，下載 { -brand-name-firefox }


### PR DESCRIPTION
This page was a mix of new strings and migrated strings, but many of the migrated ones are also obsolete and replaced by new equivalents in a separate shared.ftl file (see #74).

So this one feels especially messy and I'm not really sure of the best way to do this. I was thinking about just scrapping all the old strings and treating this as a brand new page with no migration at all. Would that be preferable than having all of these marked as obsolete?

Bedrock PR: https://github.com/mozilla/bedrock/pull/9105