### PR TITLE
Add firefox/whatsnew/whatsnew-fx79.ftl

### DIFF
--- a/ach/brands.ftl
+++ b/ach/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/af/brands.ftl
+++ b/af/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/am/brands.ftl
+++ b/am/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/an/brands.ftl
+++ b/an/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ar/brands.ftl
+++ b/ar/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ast/brands.ftl
+++ b/ast/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/az/brands.ftl
+++ b/az/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/azz/brands.ftl
+++ b/azz/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/be/brands.ftl
+++ b/be/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/bg/brands.ftl
+++ b/bg/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/bn/brands.ftl
+++ b/bn/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/br/brands.ftl
+++ b/br/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/bs/brands.ftl
+++ b/bs/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ca/brands.ftl
+++ b/ca/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/cak/brands.ftl
+++ b/cak/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/crh/brands.ftl
+++ b/crh/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/cs/brands.ftl
+++ b/cs/brands.ftl
@@ -357,6 +357,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/cy/brands.ftl
+++ b/cy/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/da/brands.ftl
+++ b/da/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/de/brands.ftl
+++ b/de/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/dsb/brands.ftl
+++ b/dsb/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/el/brands.ftl
+++ b/el/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/en-CA/brands.ftl
+++ b/en-CA/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/en-GB/brands.ftl
+++ b/en-GB/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/en/brands.ftl
+++ b/en/brands.ftl
@@ -77,6 +77,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/en/firefox/whatsnew/whatsnew-fx79.ftl
+++ b/en/firefox/whatsnew/whatsnew-fx79.ftl
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/79.0/whatsnew/all/
+
+# HTML page title
+whatsnew79-page-title = What’s new with { -brand-name-firefox }
+
+# Main title
+whatsnew79-main-title = Keep your data private from everyone – including us
+whatsnew79-main-intro = The internet should be a safe place for all. That’s why { -brand-name-firefox } doesn’t follow you around online, and stops others from following you, too.
+
+# Main CTA button
+whatsnew79-primary-cta = Make { -brand-name-firefox } Default
+
+# Fallback CTA button, shown if Firefox is already a user's default browser
+whatsnew79-fallback-cta = Get the { -brand-name-firefox } App
+
+whatsnew79-secure-your-connection = Secure your connection
+whatsnew79-with-one-tap-mozilla-vpn = With one tap, { -brand-name-mozilla-vpn } encrypts your connection to keep your online activity private on any network — safe from hackers and other prying eyes.
+
+# CTA link
+whatsnew79-get-started = Get Started
+
+whatsnew79-get-more-control-over = Get more control over trackers
+whatsnew79-firefox-blocks-more = { -brand-name-firefox } blocks more advertisers and trackers from following you around than ever before.
+
+# CTA link
+whatsnew79-see-your-report = See your Report
+whatsnew79-update-your-firefox = Update your { -brand-name-firefox } browser
+whatsnew79-download-the-firefox = Download the { -brand-name-firefox } browser
+whatsnew79-read-our-privacy-promise = Read our Privacy Promise
+whatsnew79-take-less-keep-it-safe = Take less. Keep it safe. No secrets. Our business doesn’t depend on secretly abusing your trust.
+
+# CTA link
+whatsnew79-read-more = Read More
+whatsnew79-keep-facebook-contained = Keep { -brand-name-facebook } contained
+whatsnew79-get-the-power-to-prevent = Get the power to prevent { -brand-name-facebook } and { -brand-name-instagram } from tracking you around the web.
+
+# CTA link
+whatsnew79-add-facebook-container = Add { -brand-name-facebook-container }
+
+# Modal title
+whatsnew79-get-firefox-on-your-phone = Get { -brand-name-firefox } on your Phone
+whatsnew79-scan-the-qr-code = Scan the QR code to get started
+
+# Accessible text replacement for a QR code image
+whatsnew79-qr-code-to-scan = QR code to scan for { -brand-name-firefox }

--- a/eo/brands.ftl
+++ b/eo/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/es-AR/brands.ftl
+++ b/es-AR/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/es-CL/brands.ftl
+++ b/es-CL/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/es-ES/brands.ftl
+++ b/es-ES/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/es-MX/brands.ftl
+++ b/es-MX/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/et/brands.ftl
+++ b/et/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/eu/brands.ftl
+++ b/eu/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/fa/brands.ftl
+++ b/fa/brands.ftl
@@ -78,6 +78,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ff/brands.ftl
+++ b/ff/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/fi/brands.ftl
+++ b/fi/brands.ftl
@@ -110,6 +110,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/fr/brands.ftl
+++ b/fr/brands.ftl
@@ -105,6 +105,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/fy-NL/brands.ftl
+++ b/fy-NL/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ga-IE/brands.ftl
+++ b/ga-IE/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/gd/brands.ftl
+++ b/gd/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/gl/brands.ftl
+++ b/gl/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/gn/brands.ftl
+++ b/gn/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/gu-IN/brands.ftl
+++ b/gu-IN/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/he/brands.ftl
+++ b/he/brands.ftl
@@ -90,6 +90,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/hi-IN/brands.ftl
+++ b/hi-IN/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/hr/brands.ftl
+++ b/hr/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/hsb/brands.ftl
+++ b/hsb/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/hto/brands.ftl
+++ b/hto/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/hu/brands.ftl
+++ b/hu/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/hy-AM/brands.ftl
+++ b/hy-AM/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ia/brands.ftl
+++ b/ia/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/id/brands.ftl
+++ b/id/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/is/brands.ftl
+++ b/is/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/it/brands.ftl
+++ b/it/brands.ftl
@@ -97,6 +97,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ja/brands.ftl
+++ b/ja/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ka/brands.ftl
+++ b/ka/brands.ftl
@@ -102,6 +102,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/kab/brands.ftl
+++ b/kab/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/kk/brands.ftl
+++ b/kk/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/km/brands.ftl
+++ b/km/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/kn/brands.ftl
+++ b/kn/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ko/brands.ftl
+++ b/ko/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/lij/brands.ftl
+++ b/lij/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/lo/brands.ftl
+++ b/lo/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/lt/brands.ftl
+++ b/lt/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ltg/brands.ftl
+++ b/ltg/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/lv/brands.ftl
+++ b/lv/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/mk/brands.ftl
+++ b/mk/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ml/brands.ftl
+++ b/ml/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/mr/brands.ftl
+++ b/mr/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ms/brands.ftl
+++ b/ms/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/my/brands.ftl
+++ b/my/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/nb-NO/brands.ftl
+++ b/nb-NO/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ne-NP/brands.ftl
+++ b/ne-NP/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/nl/brands.ftl
+++ b/nl/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/nn-NO/brands.ftl
+++ b/nn-NO/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/nv/brands.ftl
+++ b/nv/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/oc/brands.ftl
+++ b/oc/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/pa-IN/brands.ftl
+++ b/pa-IN/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/pai/brands.ftl
+++ b/pai/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/pbb/brands.ftl
+++ b/pbb/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ppl/brands.ftl
+++ b/ppl/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/pt-BR/brands.ftl
+++ b/pt-BR/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/pt-PT/brands.ftl
+++ b/pt-PT/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/qvi/brands.ftl
+++ b/qvi/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/rm/brands.ftl
+++ b/rm/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ro/brands.ftl
+++ b/ro/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ru/brands.ftl
+++ b/ru/brands.ftl
@@ -103,6 +103,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/si/brands.ftl
+++ b/si/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/sk/brands.ftl
+++ b/sk/brands.ftl
@@ -326,6 +326,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/sl/brands.ftl
+++ b/sl/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/son/brands.ftl
+++ b/son/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/sq/brands.ftl
+++ b/sq/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/sr/brands.ftl
+++ b/sr/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/sv-SE/brands.ftl
+++ b/sv-SE/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/sw/brands.ftl
+++ b/sw/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ta/brands.ftl
+++ b/ta/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/te/brands.ftl
+++ b/te/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/th/brands.ftl
+++ b/th/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/tl/brands.ftl
+++ b/tl/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/tr/brands.ftl
+++ b/tr/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/trs/brands.ftl
+++ b/trs/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/uk/brands.ftl
+++ b/uk/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/ur/brands.ftl
+++ b/ur/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/uz/brands.ftl
+++ b/uz/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/vi/brands.ftl
+++ b/vi/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/wo/brands.ftl
+++ b/wo/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/xh/brands.ftl
+++ b/xh/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/zam/brands.ftl
+++ b/zam/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/zh-TW/brands.ftl
+++ b/zh-TW/brands.ftl
@@ -79,6 +79,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 

--- a/zu/brands.ftl
+++ b/zu/brands.ftl
@@ -76,6 +76,7 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
 


### PR DESCRIPTION
Adds strings for the what's new page for Firefox 79.

Bedrock PR: https://github.com/mozilla/bedrock/pull/9139
Temporary demo: https://www-demo-pr-9139.herokuapp.com/firefox/79.0/whatsnew/all/

There's some conditional content so not all text is always visible on the screen.

- If Firefox is already the user's default browser they get an alternate mobile CTA that opens the send-to-device widget in a modal.
- Mozilla VPN promo is only shown to English locales.
- Facebook Container is NOT shown to zh-CN, who gets the Privacy Promise blurb in its place.