### PR TITLE
Add new navigation and sub-navigation, updates to footer and brands

### DIFF
--- a/en/brands.ftl
+++ b/en/brands.ftl
@@ -64,6 +64,7 @@
 -brand-name-firefox-monitor = Firefox Monitor
 -brand-name-firefox-send = Firefox Send
 -brand-name-firefox-sync = Firefox Sync
+-brand-name-firefox-relay = Firefox Relay
 -brand-name-firefox-private-network = Firefox Private Network
 
 ## Firefox products (short names)
@@ -73,6 +74,8 @@
 -brand-name-monitor = Monitor
 -brand-name-send = Send
 -brand-name-sync = Sync
+-brand-name-relay = Relay
+-brand-name-fpn = FPN
 
 ## Firefox products (legacy)
 
@@ -108,6 +111,9 @@
 ## Open Source projects
 
 -brand-name-rust = Rust
+-brand-name-webassembly = WebAssembly
+
+# Outdated string
 -brand-name-web-assembly = Web Assembly
 
 ## Other browsers

--- a/en/footer.ftl
+++ b/en/footer.ftl
@@ -3,22 +3,50 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 footer-firefox = { -brand-name-firefox }
+footer-mozilla-manifesto = { -brand-name-mozilla } Manifesto
+footer-privacy-hub = Privacy Hub
 footer-privacy = Privacy
 footer-press = Press
+footer-corporate-blog = Corporate Blog
+footer-browser-comparison = Browser Comparison
 footer-brand-standards = Brand Standards
 footer-browsers = Browsers
+
+# Outdated string
 footer-desktop = Desktop
+
+# Outdated string
 footer-mobile = Mobile
+
+# Outdated string
 footer-reality = { -brand-name-reality }
 footer-enterprise = { -brand-name-enterprise }
+
+# Outdated string
 footer-products = Products
+
+# Outdated string
 footer-lockwise = { -brand-name-lockwise }
+
+# Outdated string
 footer-monitor = { -brand-name-monitor }
+
+# Outdated string
 footer-send = { -brand-name-send }
+
+# Outdated string
 footer-pocket = { -brand-name-pocket }
+
+# Outdated string
 footer-join = Join
+
+# Outdated string
 footer-sign-up = Sign Up
+
+# Outdated string
 footer-sign-in = Sign In
+
+# Outdated string
 footer-benefits = Benefits
 footer-developers = Developers
 footer-developer-edition = { -brand-name-developer-edition }
@@ -30,10 +58,16 @@ footer-visit-mozilla-corporations = Visit <a { $moco_link }>{ -brand-name-mozill
 footer-portions-of-this-content = Portions of this content are ©1998–{ $current_year } by individual mozilla.org contributors. Content available under a <a rel="license" href="{ $url }">{ -brand-name-creative-commons } license</a>.
 footer-mozilla = { -brand-name-mozilla }
 footer-company = Company
+
+# Outdated string
 footer-about = About
 footer-press-center = Press Center
 footer-careers = Careers
+
+# Outdated string
 footer-test-new-features = Test New Features
+
+# Outdated string
 footer-mdn-web-docs = { -brand-name-mdn-web-docs }
 footer-tools = Tools
 footer-resources = Resources
@@ -47,6 +81,9 @@ footer-websites-cookies = Cookies
 footer-websites-legal = Legal
 footer-language = Language
 footer-go = Go
+footer-donate = Donate
 footer-twitter = { -brand-name-twitter }
 footer-instagram = { -brand-name-instagram }
 footer-youtube = { -brand-name-youtube }
+footer-follow-mozilla = Follow @{ -brand-name-mozilla }
+footer-follow-firefox = Follow @{ -brand-name-firefox }

--- a/en/navigation_v2.ftl
+++ b/en/navigation_v2.ftl
@@ -10,10 +10,10 @@ navigation-v2-menu = Menu
 
 ## Firefox menu
 
-navigation-v2-firefox-browsers = { -brand-name-firefox } Browsers
-navigation-v2-close-firefox-browsers-menu = Close { -brand-name-firefox } Browsers menu
+navigation-v2-firefox-browsers = { -brand-name-firefox-browsers }
+navigation-v2-close-firefox-browsers-menu = Close { -brand-name-firefox-browsers } menu
 navigation-v2-firefox-for-desktop = { -brand-name-firefox } for Desktop
-navigation-v2-get-the-non-profit-backed = Get the non-profit-backed browser on { -brand-name-windows }, { -brand-name-mac-short } or { -brand-name-linux }.
+navigation-v2-get-the-not-for-profit-backed = Get the not-for-profit-backed browser on { -brand-name-windows }, { -brand-name-mac-short } or { -brand-name-linux }.
 navigation-v2-firefox-for-android = { -brand-name-firefox } for { -brand-name-android }
 navigation-v2-get-the-customizable-mobile = Get the customizable mobile browser for { -brand-name-android } smartphones.
 navigation-v2-firefox-for-ios = { -brand-name-firefox } for { -brand-name-ios }
@@ -21,10 +21,10 @@ navigation-v2-get-the-mobile-browser = Get the mobile browser for your { -brand-
 navigation-v2-privacy-promise = Privacy Promise
 navigation-v2-learn-how-firefox-treats = Learn how { -brand-name-firefox } treats your data with respect.
 navigation-v2-firefox-blog = { -brand-name-firefox } Blog
-navigation-v2-read-about-new-firefox-features = Read about new Firefox features and ways to stay safe online.
+navigation-v2-read-about-new-firefox-features = Read about new { -brand-name-firefox } features and ways to stay safe online.
 navigation-v2-release-notes = Release Notes
 navigation-v2-get-the-details-on-the = Get the details on the latest { -brand-name-firefox } updates.
-navigation-v2-view-all-firefox-browsers = View all { -brand-name-firefox } Browsers
+navigation-v2-view-all-firefox-browsers = View all { -brand-name-firefox-browsers }
 
 ## Products menu
 
@@ -35,11 +35,11 @@ navigation-v2-see-if-your-email-has = See if your email has appeared in a compan
 navigation-v2-pocket = { -brand-name-pocket }
 navigation-v2-save-and-discover-the-best = Save and discover the best stories from across the web.
 navigation-v2-facebook-container = { -brand-name-facebook-container }
-navigation-v2-help-prevent-facebook-from = Help prevent Facebook from collecting your data outside their site.
+navigation-v2-help-prevent-facebook-from = Help prevent { -brand-name-facebook } from collecting your data outside their site.
 navigation-v2-mozilla-vpn = { -brand-name-mozilla-vpn }
 navigation-v2-get-protection-beyond-your-browser = Get protection beyond your browser, on all your devices.
 navigation-v2-product-promise = Product Promise
-navigation-v2-learn-how-each-firefox-product = Learn how each Firefox product protects and respects your data.
+navigation-v2-learn-how-each-firefox-product = Learn how each { -brand-name-firefox } product protects and respects your data.
 navigation-v2-firefox-relay-beta = { -brand-name-firefox-relay } (beta)
 navigation-v2-sign-up-for-new-accounts = Sign up for new accounts without handing over your email address.
 navigation-v2-firefox-private-network-beta = { -brand-name-firefox-private-network } (beta)
@@ -53,7 +53,7 @@ navigation-v2-close-who-we-are-menu = Close Who We Are menu
 navigation-v2-mozilla-manifesto = { -brand-name-mozilla } Manifesto
 navigation-v2-learn-about-the-values = Learn about the values and principles that guide our mission.
 navigation-v2-mozilla-foundation = { -brand-name-mozilla-foundation }
-navigation-v2-meet-the-non-profit-behind = Meet the non-profit behind { -brand-name-firefox } that stands for a better web.
+navigation-v2-meet-the-not-for-profit-behind = Meet the not-for-profit behind { -brand-name-firefox } that stands for a better web.
 navigation-v2-get-involved = Get involved
 navigation-v2-join-the-fight-for-a = Join the fight for a healthy internet.
 navigation-v2-leadership = Leadership

--- a/en/navigation_v2.ftl
+++ b/en/navigation_v2.ftl
@@ -1,0 +1,93 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+navigation-v2-mozilla = { -brand-name-mozilla }
+navigation-v2-download-firefox = Download { -brand-name-firefox }
+navigation-v2-get-a-firefox-account = Get a { -brand-name-firefox-account }
+navigation-v2-menu = Menu
+
+## Firefox menu
+
+navigation-v2-firefox-browsers = { -brand-name-firefox } Browsers
+navigation-v2-close-firefox-browsers-menu = Close { -brand-name-firefox } Browsers menu
+navigation-v2-firefox-for-desktop = { -brand-name-firefox } for Desktop
+navigation-v2-get-the-non-profit-backed = Get the non-profit-backed browser on { -brand-name-windows }, { -brand-name-mac-short } or { -brand-name-linux }.
+navigation-v2-firefox-for-android = { -brand-name-firefox } for { -brand-name-android }
+navigation-v2-get-the-customizable-mobile = Get the customizable mobile browser for { -brand-name-android } smartphones.
+navigation-v2-firefox-for-ios = { -brand-name-firefox } for { -brand-name-ios }
+navigation-v2-get-the-mobile-browser = Get the mobile browser for your { -brand-name-iphone } or { -brand-name-ipad }.
+navigation-v2-privacy-promise = Privacy Promise
+navigation-v2-learn-how-firefox-treats = Learn how { -brand-name-firefox } treats your data with respect.
+navigation-v2-firefox-blog = { -brand-name-firefox } Blog
+navigation-v2-read-about-new-firefox-features = Read about new Firefox features and ways to stay safe online.
+navigation-v2-release-notes = Release Notes
+navigation-v2-get-the-details-on-the = Get the details on the latest { -brand-name-firefox } updates.
+navigation-v2-view-all-firefox-browsers = View all { -brand-name-firefox } Browsers
+
+## Products menu
+
+navigation-v2-products = Products
+navigation-v2-close-products-menu = Close Products menu
+navigation-v2-firefox-monitor = { -brand-name-firefox-monitor }
+navigation-v2-see-if-your-email-has = See if your email has appeared in a company’s data breach.
+navigation-v2-pocket = { -brand-name-pocket }
+navigation-v2-save-and-discover-the-best = Save and discover the best stories from across the web.
+navigation-v2-facebook-container = { -brand-name-facebook-container }
+navigation-v2-help-prevent-facebook-from = Help prevent Facebook from collecting your data outside their site.
+navigation-v2-mozilla-vpn = { -brand-name-mozilla-vpn }
+navigation-v2-get-protection-beyond-your-browser = Get protection beyond your browser, on all your devices.
+navigation-v2-product-promise = Product Promise
+navigation-v2-learn-how-each-firefox-product = Learn how each Firefox product protects and respects your data.
+navigation-v2-firefox-relay-beta = { -brand-name-firefox-relay } (beta)
+navigation-v2-sign-up-for-new-accounts = Sign up for new accounts without handing over your email address.
+navigation-v2-firefox-private-network-beta = { -brand-name-firefox-private-network } (beta)
+navigation-v2-protect-your-browsers-connection = Protect your browser’s connection to the internet.
+navigation-v2-view-all-products = View all Products
+
+## Who We Are menu
+
+navigation-v2-who-we-are = Who We Are
+navigation-v2-close-who-we-are-menu = Close Who We Are menu
+navigation-v2-mozilla-manifesto = { -brand-name-mozilla } Manifesto
+navigation-v2-learn-about-the-values = Learn about the values and principles that guide our mission.
+navigation-v2-mozilla-foundation = { -brand-name-mozilla-foundation }
+navigation-v2-meet-the-non-profit-behind = Meet the non-profit behind { -brand-name-firefox } that stands for a better web.
+navigation-v2-get-involved = Get involved
+navigation-v2-join-the-fight-for-a = Join the fight for a healthy internet.
+navigation-v2-leadership = Leadership
+navigation-v2-meet-the-team-thats-building = Meet the team that’s building technology for a better internet.
+navigation-v2-careers = Careers
+navigation-v2-work-for-a-mission-driven-updated = Work for a mission-driven organization that makes people-first products.
+navigation-v2-mozilla-blog = { -brand-name-mozilla } Blog
+navigation-v2-learn-about-mozilla-and = Learn about { -brand-name-mozilla } and the issues that matter to us.
+navigation-v2-more-about-mozilla = More About { -brand-name-mozilla }
+
+## Innovation menu
+
+navigation-v2-innovation = Innovation
+navigation-v2-close-innovation-menu = Close Innovation menu
+navigation-v2-mozilla-hubs = { -brand-name-mozilla-hubs }
+navigation-v2-gather-in-this-interactive-online = Gather in this interactive, online, multi-dimensional social space.
+navigation-v2-firefox-developer-edition = { -brand-name-firefox-developer-edition }
+navigation-v2-get-the-firefox-browser-built = Get the { -brand-name-firefox } browser built just for developers.
+navigation-v2-mdn-web-docs = { -brand-name-mdn-web-docs }
+navigation-v2-check-out-the-home-for-web = Check out the home for web developer resources.
+navigation-v2-firefox-reality = { -brand-name-firefox-reality }
+navigation-v2-explore-the-web-with-the = Explore the web with the { -brand-name-firefox } browser for virtual reality.
+navigation-v2-common-voice = { -brand-name-common-voice }
+navigation-v2-donate-your-voice-so-the-future = Donate your voice so the future of the web can hear everyone.
+navigation-v2-webassembly = { -brand-name-webassembly }
+navigation-v2-learn-more-about-the-new = Learn more about the new, low-level, assembly-like language.
+navigation-v2-more-mozilla-innovation = More { -brand-name-mozilla } Innovation
+
+
+
+
+
+
+
+
+
+

--- a/en/sub_navigation.ftl
+++ b/en/sub_navigation.ftl
@@ -1,0 +1,54 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+sub-navigation-all-languages = All Languages
+sub-navigation-firefox = { -brand-name-firefox }
+sub-navigation-chrome = { -brand-name-chrome }
+sub-navigation-edge = { -brand-name-edge }
+sub-navigation-ie = { -brand-name-ie }
+sub-navigation-opera = { -brand-name-opera }
+sub-navigation-safari = { -brand-name-safari }
+sub-navigation-brave = { -brand-name-brave }
+sub-navigation-compare-browsers = Compare Browsers
+sub-navigation-firefox-for-desktop = { -brand-name-firefox } for Desktop
+sub-navigation-release-notes = Release Notes
+sub-navigation-desktop = Desktop
+sub-navigation-android = { -brand-name-android }
+sub-navigation-ios = { -brand-name-ios }
+sub-navigation-ios-support = { -brand-name-ios } Support
+sub-navigation-android-support = { -brand-name-android } Support
+sub-navigation-android-beta = { -brand-name-android } { -brand-name-beta }
+sub-navigation-desktop-beta-and-developer = Desktop { -brand-name-beta } & { -brand-name-developer-edition }
+sub-navigation-desktop-nightly = Desktop { -brand-name-nightly }
+sub-navigation-features = Features
+sub-navigation-support = Support
+sub-navigation-addons = Addons
+sub-navigation-faq = FAQ
+sub-navigation-learn-more = Learn More
+sub-navigation-developer-edition = { -brand-name-developer-edition }
+sub-navigation-firefox-for-mobile = { -brand-name-firefox } for Mobile
+sub-navigation-android-addons = { -brand-name-android } Addons
+sub-navigation-chromebook = { -brand-name-chromebook }
+sub-navigation-firefox-accounts = { -brand-name-firefox-accounts }
+sub-navigation-sync = { -brand-name-sync }
+sub-navigation-lockwise = { -brand-name-lockwise }
+sub-navigation-windows = { -brand-name-windows }
+sub-navigation-windows-64-bit = { -brand-name-windows } 64-bit
+sub-navigation-mac = { -brand-name-mac-short }
+sub-navigation-linux = { -brand-name-linux }
+sub-navigation-enterprise = { -brand-name-enterprise }
+sub-navigation-nightly-and-beta = { -brand-name-nightly } and { -brand-name-beta }
+sub-navigation-android-nightly-and-beta = { -brand-name-android } { -brand-name-nightly } and { -brand-name-beta }
+sub-navigation-ios-test-flight = { -brand-name-ios } { -brand-name-test-flight }
+sub-navigation-firefox-features = { -brand-name-firefox } Features
+sub-navigation-ad-tracker-blocking = Ad Tracker Blocking
+sub-navigation-private-browsing = Private Browsing
+sub-navigation-what-is-a-browser = What is a Browser?
+sub-navigation-browsing-history = Browsing History
+sub-navigation-browser-history = Browser History
+sub-navigation-privacy = Privacy
+sub-navigation-our-promise= Our Promise
+sub-navigation-our-products = Our Products
+sub-navigation-little-book-of-privacy = Little Book of Privacy


### PR DESCRIPTION
This adds new files for redesigned global navigation and sub-navigation. sub-navigation.ftl will be a global Fluent file in bedrock, even though only some pages have subnav; it's more practical to keep the strings consolidated since many get re-used on different pages (also some of those pages aren't converted to Fluent yet).

This also makes a bunch of changes to footer.ftl, but I wonder if it's better to create a footer-v2.ftl? A lot of existing strings are remaining, but there are several new ones and a lot becoming obsolete. Would a new file be cleaner?

Also adding a few new brand names.

Nav is being added to bedrock in https://github.com/mozilla/bedrock/pull/9650. I've use fallback strings from the old nav where possible, and in other cases I'm using `ftl_has_messages` to hide strings until they're translated.

Currently viewable on demo at https://www-demo1.allizom.org