### PR TITLE
Add MR1 home promo

### DIFF
--- a/en/mozorg/home-mr1-promo.ftl
+++ b/en/mozorg/home-mr1-promo.ftl
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/ ('en-US', 'en-CA', 'en-GB', 'de' and 'fr' excluded)
+
+home-promo-title-lalo = Open up fresh ideas
+home-promo-title-soraya = Fire starts here
+home-promo-title-gary = The choices you make matter
+home-promo-title-ryan = Fire starts here
+
+home-promo-desc-lalo = Restaurateur, Firefox fan
+home-promo-desc-soraya = Furniture designer, Firefox fan
+home-promo-desc-gary = Surfboard shaper, Firefox fan
+home-promo-desc-ryan = Artist, actress, athlete & activist, Firefox fan


### PR DESCRIPTION
There are four different promos, randomly selected when the page loads.

It hasn't merged yet so it's not yet available on dev, but it's on a demo server at https://www-demo4.allizom.org/ and you can see all four promos at https://www-demo4.allizom.org/home-test/