### PR TITLE
Fix brand names in MR1 promo

### DIFF
--- a/en/mozorg/home-mr1-promo.ftl
+++ b/en/mozorg/home-mr1-promo.ftl
@@ -2,14 +2,26 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-### URL: https://www-dev.allizom.org/ ('en-US', 'en-CA', 'en-GB', 'de' and 'fr' excluded)
+### URL: https://www-dev.allizom.org/
 
 home-promo-title-lalo = Open up fresh ideas
 home-promo-title-soraya = Fire starts here
 home-promo-title-gary = The choices you make matter
 home-promo-title-ryan = Fire starts here
 
+home-promo-desc-lalo-updated = Restaurateur, { -brand-name-firefox } fan
+home-promo-desc-soraya-updated = Furniture designer, { -brand-name-firefox } fan
+home-promo-desc-gary-updated = Surfboard shaper, { -brand-name-firefox } fan
+home-promo-desc-ryan-updated = Artist, actress, athlete & activist, { -brand-name-firefox } fan
+
+# Obsolete string
 home-promo-desc-lalo = Restaurateur, Firefox fan
+
+# Obsolete string
 home-promo-desc-soraya = Furniture designer, Firefox fan
+
+# Obsolete string
 home-promo-desc-gary = Surfboard shaper, Firefox fan
+
+# Obsolete string
 home-promo-desc-ryan = Artist, actress, athlete & activist, Firefox fan


### PR DESCRIPTION
Adds the brand name fixes as new strings, and we can keep the old ones as fallbacks for those locales who already translated them.