### PR TITLE
Add MR1 promo CTA string

### DIFF
--- a/en/mozorg/home-mr1-promo.ftl
+++ b/en/mozorg/home-mr1-promo.ftl
@@ -9,6 +9,8 @@ home-promo-title-soraya = Fire starts here
 home-promo-title-gary = The choices you make matter
 home-promo-title-ryan = Fire starts here
 
+home-promo-explore-firefox = Explore { -brand-name-firefox }
+
 home-promo-desc-lalo-updated = Restaurateur, { -brand-name-firefox } fan
 home-promo-desc-soraya-updated = Furniture designer, { -brand-name-firefox } fan
 home-promo-desc-gary-updated = Surfboard shaper, { -brand-name-firefox } fan


### PR DESCRIPTION
New string for the button shown to Firefox users. We'll use the standard "Learn more" as a fallback for any locales that have already completed this file and don't get to the new string.