### PR TITLE
Fix unclosed href in link to cpg-report@mozilla.com

### DIFF
--- a/es-ES/mozorg/about/governance/policies/reporting.ftl
+++ b/es-ES/mozorg/about/governance/policies/reporting.ftl
@@ -16,7 +16,7 @@ reporting-please-report-all-incidents = Por favor, denuncia todos los incidentes
 reporting-how-to-give-a-report = Cómo presentar una denuncia
 reporting-if-you-believe-someone = Si crees que alguien está en peligro físicamente, llama al teléfono de emergencias de tu país.
 reporting-if-you-have-a-report-by = Si se trata de una denuncia realizada <strong>por <em>y</em> sobre</strong> un colaborador (por ejemplo, cuando un colaborador denuncia el comportamiento de otro colaborador ), en ese caso debes hacer la denuncia a través de la <a href="{ $community_hotline }">línea directa para asuntos relacionados con las Pautas para la participación en la comunidad</a>.
-reporting-if-you-have-a-report-by-email = Si tienes una denuncia<strong>de <em>y</em> acerca de</strong> un colaborador (por ejemplo, la denuncia es <strong>de</strong> un colaborador <strong>acerca de</strong> otro colaborador), entonces deberías hacer tu denuncia en <a href="{ $mailto_report }>cpg-report@mozilla.com</a>.
+reporting-if-you-have-a-report-by-email = Si tienes una denuncia<strong>de <em>y</em> acerca de</strong> un colaborador (por ejemplo, la denuncia es <strong>de</strong> un colaborador <strong>acerca de</strong> otro colaborador), entonces deberías hacer tu denuncia en <a href="{ $mailto_report }">cpg-report@mozilla.com</a>.
 reporting-if-you-have-a-report-involving = Si se trata de una denuncia<strong>que involucra a un empleado, contratista o proveedor</strong> (por ejemplo, cuando la denuncia la presenta un empleado o involucra a un empleado), en ese caso debes informarnos a través de la <a href="{ $employee_hotline }">línea directa para empleados de { -brand-name-mozilla }</a>.
 reporting-put-another-way = Dicho de otra manera:
 reporting-by = Por


### PR DESCRIPTION
A tool I am writing to check the content of mozilla.org spotted some malformed markup in a link node, because the closing `"` of the href attribute was missing.