### PR TITLE
Remove leading and trailing spaces around URL and in link markup

### DIFF
--- a/cy/mozorg/about/this-site.ftl
+++ b/cy/mozorg/about/this-site.ftl
@@ -35,7 +35,7 @@ about-this-site-django = <a href="{ $django }">Django</a> y fframwaith gwe cefn,
 about-this-site-mozilla-protocol = System ddylunio <a href="{ $protocol }">Protocol</a> ar gyfer cydrannau pen blaen a brandio { -brand-name-mozilla }.
 # Variables:
 #   $fluent (url) link to https://projectfluent.org/
-about-this-site-fluent = System leoleiddio <a href = " { $fluent } "> Fluent</a> { -brand-name-mozilla } ar gyfer cyfieithu.
+about-this-site-fluent = System leoleiddio <a href="{ $fluent }">Fluent</a> { -brand-name-mozilla } ar gyfer cyfieithu.
 # Variables:
 #   $github (url) link to https://github.com/mozilla/bedrock
 about-this-site-many-other = Llawer o lyfrgelloedd a fframweithiau llai eraill, y gallwch ddod o hyd iddyn nhw yn ein  storfa <a href="{ $github }">{ -brand-name-github }</a>.


### PR DESCRIPTION
Extra spaces around the URL `$fluent` were causing `www-site-checker` to flag the outbound URL as unapproved.

Identified via https://github.com/mozmeao/www-site-checker/actions/runs/2782967944