### PR TITLE
Add GH Action workflow to trigger Bedrock's Fluent-file importer when changes land here

### DIFF
--- a/.github/workflows/notify_bedrock_of_updates.yaml
+++ b/.github/workflows/notify_bedrock_of_updates.yaml
@@ -8,6 +8,10 @@ on:
       - master
   workflow_dispatch: # For manual runs, if needed
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   notify-of-updates:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify_bedrock_of_updates.yaml
+++ b/.github/workflows/notify_bedrock_of_updates.yaml
@@ -1,0 +1,24 @@
+# Notify Bedrock that l10n files have updated, by pinging Bedrock's Fluent-files
+# update pipeline at mozmeao/www-fluent-update
+
+name: Ping mozmeao/www-fluent-update when master changes
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch: # For manual runs, if needed
+
+jobs:
+  notify-of-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Trigger webhook"
+        shell: bash
+        run: >
+          curl -X POST
+          https://api.github.com/repos/mozmeao/www-fluent-update/actions/workflows/run-fluent-updates.yml/dispatches
+          --header "Accept: application/vnd.github+json"
+          --header "Authorization: Bearer ${{ secrets.WWW_FLUENT_UPDATE_PAT }}"
+          --header "Content-Type: application/json"
+          -d '{"ref":"main"}'
+        # 'main' as the ref above refers to the branch on the www-fluent-update repo

--- a/.github/workflows/notify_bedrock_of_updates.yaml
+++ b/.github/workflows/notify_bedrock_of_updates.yaml
@@ -12,7 +12,7 @@ jobs:
   notify-of-updates:
     runs-on: ubuntu-latest
     steps:
-      - name: "Trigger webhook"
+      - name: Trigger webhook
         shell: bash
         run: >
           curl -X POST


### PR DESCRIPTION
This change is part of moving our CI from Gitlab to GH Actions. 

The access token mentioned here has been added to Github already as a secret

The workflow has been tested on my fork of www-l10n and [worked fine](https://github.com/stevejalim/www-l10n/actions/runs/4786097543/jobs/8509674273)

It can be merged at any time. I'm aware that it might get a bit noisy, but if we need to throttle things, we can do that at the receiving end.

Thanks for the review!